### PR TITLE
Use docker client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 
 dependencies = [
     "adbc-driver-postgresql>=1.9.0",
+    "docker>=7.1.0",
     "fastapi>=0.125.0",
     "ipykernel==7.0.1",
     "matplotlib>=3.10.8",

--- a/src/acquirium/Dockerfile
+++ b/src/acquirium/Dockerfile
@@ -2,9 +2,9 @@ FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
 
 WORKDIR /app
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends docker.io ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
+#RUN apt-get update \
+#  && apt-get install -y --no-install-recommends docker.io ca-certificates \
+#  && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml /app/pyproject.toml
 COPY src /app/src

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -19,9 +19,9 @@ import hashlib
 import threading
 from concurrent.futures import ThreadPoolExecutor, Future
 from typing import Any
-import subprocess
-import shlex
 import shutil
+import docker
+from docker.errors import DockerException, NotFound as ContainerNotFound
 from acquirium.Server.mqtt_ingestion import MQTTIngestService, MQTTStreamSpec
 
 logging.basicConfig(level=logging.INFO)
@@ -139,8 +139,16 @@ class Manager:
         self.app_storage_root.mkdir(parents=True, exist_ok=True)
         self._app_runs: dict[str, dict[str, Any]] = {}
         self._app_runs_lock = threading.Lock()
-        
-    
+
+        # Initialize Docker client for spawning app containers
+        try:
+            self._docker = docker.from_env()
+            self._docker.ping()
+            logger.info("acquirium: connected to Docker daemon")
+        except DockerException as e:
+            logger.warning("acquirium: Docker not available, app execution disabled: %s", e)
+            self._docker = None
+
     @classmethod
     def from_env(cls) -> Manager:
         return cls(
@@ -435,6 +443,9 @@ class Manager:
         }
 
     def _run_app_once(self, req: AppRunRequest, *, keep_alive: bool = False, interval: float | None = None) -> str:
+        if self._docker is None:
+            raise ValueError("Docker is not available - cannot run apps")
+
         runtime = self._lookup_app_runtime(req.app_id)
         logger.info("Running app %s with runtime config: %s", req.app_id, runtime)
 
@@ -477,42 +488,46 @@ class Manager:
         if entry_file:
             env["ACQUIRIUM_APP_FILE"] = f"{container_app_root}/{entry_file}"
 
-        cmd = ["docker", "run", "-d", "--rm"]
+        # Filter out empty environment values
+        env = {k: v for k, v in env.items() if v}
 
         network = os.getenv("ACQUIRIUM_APP_NETWORK")
-        if network:
-            cmd.extend(["--network", network])
+        volume_name = os.getenv("ACQUIRIUM_APP_VOLUME", "acquirium_acquirium_data")
 
-        # Named volume that both server and workers share
-        cmd.extend(["-v", f"{os.getenv('ACQUIRIUM_APP_VOLUME', 'acquirium_acquirium_data')}:{container_data_root}:ro"])
+        # Build volume mount specification
+        volumes = {
+            volume_name: {"bind": container_data_root, "mode": "ro"}
+        }
 
-        for k, v in env.items():
-            if v:
-                cmd.extend(["-e", f"{k}={v}"])
-
-        entrypoint = runtime.get("entrypoint")
-        if entrypoint:
-            cmd.extend(["--entrypoint", entrypoint])
-
-        cmd.append(image)
-
+        # Build the command to run inside the container
         run_cmd = runtime.get("command") or "python -m acquirium.Apps.worker"
         shell_cmd = f"/app/.venv/bin/{run_cmd}" if run_cmd.startswith("python ") else f"/app/.venv/bin/python -m acquirium.Apps.worker"
-        cmd.extend(["sh", "-lc", shell_cmd])
 
+        # Optional custom entrypoint
+        entrypoint = runtime.get("entrypoint")
 
-        logger.info("Running docker command: %s", " ".join(shlex.quote(x) for x in cmd))
+        logger.info(
+            "Starting container: image=%s, network=%s, volume=%s, env_keys=%s",
+            image, network, volume_name, list(env.keys())
+        )
 
         try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        except subprocess.CalledProcessError as e:
-            logger.error("docker run failed: %s", " ".join(shlex.quote(x) for x in e.cmd))
-            logger.error("stdout:\n%s", e.stdout)
-            logger.error("stderr:\n%s", e.stderr)
-            raise ValueError(f"Failed to run app {req.app_id}: {e.stderr.strip()}") from e
+            container = self._docker.containers.run(
+                image=image,
+                command=["sh", "-lc", shell_cmd],
+                entrypoint=entrypoint if entrypoint else None,
+                environment=env,
+                volumes=volumes,
+                network=network if network else None,
+                detach=True,
+                auto_remove=True,
+            )
+        except DockerException as e:
+            logger.error("Failed to start container for app %s: %s", req.app_id, e)
+            raise ValueError(f"Failed to run app {req.app_id}: {e}") from e
 
-        cid = proc.stdout.strip()
-        logger.info("Started docker container for app %s: %s", req.app_id, cid)
+        cid = container.id
+        logger.info("Started docker container for app %s: %s", req.app_id, cid[:12])
         return cid
 
     def run_app(self, req: AppRunRequest) -> str:
@@ -525,10 +540,17 @@ class Manager:
         return cid
 
     def _stop_container(self, cid: str) -> None:
+        if self._docker is None:
+            logger.warning("Docker not available, cannot stop container %s", cid)
+            return
         try:
-            subprocess.run(["docker", "stop", cid], capture_output=True, text=True, check=False)
-        except Exception:
-            logger.exception("Failed to stop container %s", cid)
+            container = self._docker.containers.get(cid)
+            container.stop(timeout=10)
+            logger.info("Stopped container %s", cid[:12])
+        except ContainerNotFound:
+            logger.debug("Container %s already stopped or removed", cid[:12])
+        except DockerException:
+            logger.exception("Failed to stop container %s", cid[:12])
 
     def stop_app(self, *, run_id: str | None = None, app_id: str | None = None) -> dict[str, Any]:
         if not run_id and not app_id:


### PR DESCRIPTION
Cleaner way of creating the app containers; docker.io package is old and should not be used! Just use the docker client and connect to the host socket.

Draft PR for now; going to see if anything else needs changing.