### PR TITLE
Data ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Copy this file to .env and adjust values for your environment.
+# docker compose automatically loads .env from the project root.
+
+# ── TimescaleDB ───────────────────────────────────────────────────────────────
+POSTGRES_USER=acquirium
+POSTGRES_PASSWORD=acquirium
+POSTGRES_DB=acquirium_test
+
+# ── Acquirium Server ──────────────────────────────────────────────────────────
+
+# Connection string for the TimescaleDB instance.
+# Inside Docker Compose the hostname is the service name ("timescaledb").
+PG_DSN=postgresql://acquirium:acquirium@timescaledb:5432/acquirium_test
+
+# Directory where the server persists RDF graph data and other state.
+ACQUIRIUM_DATA_DIR=/app/.acquirium
+
+# Where fastembed caches downloaded embedding models.
+FASTEMBED_CACHE_PATH=/app/.fastembed_cache
+
+# Set to "true" to wipe and reinitialise all data on startup.
+# Forced to true by `make test` and `make rebuild`.
+ACQUIRIUM_RECREATE=false
+
+# Docker network name used when the server launches App containers.
+# Default matches the Compose-generated name: <project-dir>_acquirium_net.
+# Override if you run Compose with a custom project name (-p flag).
+ACQUIRIUM_APP_NETWORK=acquirium_acquirium_net
+
+# ── Ports (host-side) ─────────────────────────────────────────────────────────
+# Uncomment and change these if default ports conflict with other services.
+# TIMESCALEDB_PORT=5432
+# MOSQUITTO_PORT=1883
+# ACQUIRIUM_PORT=8000
+# GRAFANA_PORT=3000

--- a/compose.minimal.yaml
+++ b/compose.minimal.yaml
@@ -1,0 +1,89 @@
+services:
+  timescaledb:
+    image: timescale/timescaledb:latest-pg17
+    container_name: acquirium_timescaledb
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-acquirium}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-acquirium}
+      POSTGRES_DB: ${POSTGRES_DB:-acquirium_test}
+    ports:
+      - "${TIMESCALEDB_PORT:-5432}:5432"
+    volumes:
+      - tsdb_data:/var/lib/postgresql/data
+      - ./src/acquirium/internals/init-timescaledb.sql:/docker-entrypoint-initdb.d/init-timescaledb.sql:ro
+    networks:
+      - acquirium_net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-acquirium} -d ${POSTGRES_DB:-acquirium_test}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mosquitto:
+    image: eclipse-mosquitto:2
+    container_name: acquirium_mosquitto
+    ports:
+      - "${MOSQUITTO_PORT:-1883}:1883"
+    volumes:
+      - mosquitto_data:/mosquitto/data
+      - mosquitto_log:/mosquitto/log
+      - ./src/acquirium/internals/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+    networks:
+      - acquirium_net
+    healthcheck:
+      test: ["CMD-SHELL", "mosquitto_sub -h localhost -p 1883 -t '$$SYS/broker/version' -C 1 >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  acquirium:
+    build:
+      context: .
+      dockerfile: ./src/acquirium/Dockerfile
+    container_name: acquirium_server
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - acquirium_data:/app/.acquirium
+    ports:
+      - "${ACQUIRIUM_PORT:-8000}:8000"
+    environment:
+      ACQUIRIUM_DATA_DIR: ${ACQUIRIUM_DATA_DIR:-/app/.acquirium}
+      PG_DSN: ${PG_DSN:-postgresql://acquirium:acquirium@timescaledb:5432/acquirium_test}
+      FASTEMBED_CACHE_PATH: ${FASTEMBED_CACHE_PATH:-/app/.fastembed_cache}
+      ACQUIRIUM_RECREATE: ${ACQUIRIUM_RECREATE:-false}
+      ACQUIRIUM_APP_NETWORK: ${ACQUIRIUM_APP_NETWORK:-acquirium_acquirium_net}
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+      timescaledb:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - acquirium_net
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()\""]
+      interval: 3s
+      timeout: 2s
+      retries: 40
+      start_period: 20s
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: acquirium_grafana
+    restart: unless-stopped
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    volumes:
+      - grafana_storage:/var/lib/grafana
+    networks:
+      - acquirium_net
+
+volumes:
+  tsdb_data:
+  mosquitto_data:
+  mosquitto_log:
+  acquirium_data:
+  grafana_storage:
+
+networks:
+  acquirium_net:

--- a/deployments/BENICIA/benicia-model-with-refs-1.ttl
+++ b/deployments/BENICIA/benicia-model-with-refs-1.ttl
@@ -1,4 +1,5 @@
 @prefix acq: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix nawi: <urn:nawi-water-ontology#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -15,14 +16,13 @@ wbs:AS_Aeration_Basin-mlss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref .
 
-wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-mlss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-mlss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;

--- a/deployments/BENICIA/benicia-model-with-refs-10.ttl
+++ b/deployments/BENICIA/benicia-model-with-refs-10.ttl
@@ -1,4 +1,5 @@
 @prefix acq: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix nawi: <urn:nawi-water-ontology#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -15,125 +16,115 @@ wbs:AS_Aeration_Basin-mlss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref .
 
-wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-mlss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-mlss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-ph_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-ph_mqtt_ref .
 
-wbs:AS_Aeration_Basin-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref .
 
-wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-turbidity_mqtt_ref .
 
-wbs:AS_Aeration_Basin-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-volume_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-volume_mqtt_ref .
 
-wbs:AS_Aeration_Basin-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-ph_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-ph_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-temperature" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-temperature" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-volume_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-volume_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Chlorination_Basin-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;

--- a/deployments/BENICIA/benicia-model-with-refs-100.ttl
+++ b/deployments/BENICIA/benicia-model-with-refs-100.ttl
@@ -1,4 +1,5 @@
 @prefix acq: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix nawi: <urn:nawi-water-ontology#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -15,741 +16,681 @@ wbs:AS_Aeration_Basin-mlss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref .
 
-wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-mlss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-mlss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-ph_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-ph_mqtt_ref .
 
-wbs:AS_Aeration_Basin-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref .
 
-wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-turbidity_mqtt_ref .
 
-wbs:AS_Aeration_Basin-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Aeration_Basin-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-volume_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Aeration_Basin-volume_mqtt_ref .
 
-wbs:AS_Aeration_Basin-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-ph_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-ph_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-temperature" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-temperature" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:AS_Secondary_Sedimentation-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-volume_mqtt_ref .
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-volume_mqtt_ref .
 
-wbs:AS_Secondary_Sedimentation-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Chlorination_Basin-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Chlorination_Basin-cl2-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Chlorination_Basin-cl2-mgL_mqtt_ref .
 
-wbs:Chlorination_Basin-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Chlorination_Basin-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Chlorination_Basin-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Chlorination_Basin-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Chlorination_Basin-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Chlorination_Basin-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Chlorination_Basin-ph_mqtt_ref .
 
-wbs:Chlorination_Basin-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Chlorination_Basin-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Chlorination_Basin-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Chlorination_Basin-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Chlorination_Basin-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    acq:hasExternalReference wbs:Chlorination_Basin-temperature_mqtt_ref .
+    ref:hasExternalReference wbs:Chlorination_Basin-temperature_mqtt_ref .
 
-wbs:Chlorination_Basin-temperature_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Chlorination_Basin-temperature" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Chlorination_Basin-temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Chlorination_Basin-temperature" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Chlorination_Basin-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:Chlorination_Basin-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:Chlorination_Basin-turbidity_mqtt_ref .
 
-wbs:Chlorination_Basin-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Chlorination_Basin-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Chlorination_Basin-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Chlorination_Basin-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Chlorination_Basin-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:Chlorination_Basin-volume_mqtt_ref .
+    ref:hasExternalReference wbs:Chlorination_Basin-volume_mqtt_ref .
 
-wbs:Chlorination_Basin-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Chlorination_Basin-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Chlorination_Basin-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Chlorination_Basin-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Diurnal_Flow_Box-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Diurnal_Flow_Box-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Diurnal_Flow_Box-ph_mqtt_ref .
 
-wbs:Diurnal_Flow_Box-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Diurnal_Flow_Box-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Diurnal_Flow_Box-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Diurnal_Flow_Box-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Diurnal_Flow_Box-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    acq:hasExternalReference wbs:Diurnal_Flow_Box-temperature_mqtt_ref .
+    ref:hasExternalReference wbs:Diurnal_Flow_Box-temperature_mqtt_ref .
 
-wbs:Diurnal_Flow_Box-temperature_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Diurnal_Flow_Box-temperature" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Diurnal_Flow_Box-temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Diurnal_Flow_Box-temperature" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Diurnal_Flow_Box-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:Diurnal_Flow_Box-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:Diurnal_Flow_Box-turbidity_mqtt_ref .
 
-wbs:Diurnal_Flow_Box-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Diurnal_Flow_Box-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Diurnal_Flow_Box-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Diurnal_Flow_Box-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Diurnal_Flow_Box-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:Diurnal_Flow_Box-volume_mqtt_ref .
+    ref:hasExternalReference wbs:Diurnal_Flow_Box-volume_mqtt_ref .
 
-wbs:Diurnal_Flow_Box-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Diurnal_Flow_Box-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Diurnal_Flow_Box-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Diurnal_Flow_Box-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-in-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-in-cl2-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-in-cl2-mgL_mqtt_ref .
 
-wbs:Effluent_Pump-in-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-in-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-in-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-in-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-in-cyanide a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Cyanide ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-in-cyanide_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-in-cyanide_mqtt_ref .
 
-wbs:Effluent_Pump-in-cyanide_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-in-cyanide" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-in-cyanide_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-in-cyanide" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-in-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Effluent_Pump-in-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-in-flow-rate_mqtt_ref .
 
-wbs:Effluent_Pump-in-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-in-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-in-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-in-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-in-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Effluent_Pump-in-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-in-pressure_mqtt_ref .
 
-wbs:Effluent_Pump-in-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-in-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-in-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-in-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-in-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-in-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-in-tss-concentration_mqtt_ref .
 
-wbs:Effluent_Pump-in-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-in-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-in-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-in-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-bacteria-enterococcus a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Bacteria ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:CFU-PER-100ML ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref .
 
-wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-bacteria-enterococcus" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-bacteria-enterococcus" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-biochemical-oxygen-demand a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Oxygen ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref .
 
-wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-biochemical-oxygen-demand" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-biochemical-oxygen-demand" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref .
 
-wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-copper a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Metals ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-copper_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-copper_mqtt_ref .
 
-wbs:Effluent_Pump-out-copper_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-copper" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-copper_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-copper" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-cyanide a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Cyanide ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-cyanide_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-cyanide_mqtt_ref .
 
-wbs:Effluent_Pump-out-cyanide_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-cyanide" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-cyanide_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-cyanide" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-flow-rate_mqtt_ref .
 
-wbs:Effluent_Pump-out-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-nh4-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Ammonia ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref .
 
-wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-nh4-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-nh4-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-ph_mqtt_ref .
 
-wbs:Effluent_Pump-out-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-pressure_mqtt_ref .
 
-wbs:Effluent_Pump-out-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-teq-dioxin a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Organics ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref .
 
-wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-teq-dioxin" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-teq-dioxin" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-out-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-out-tss-concentration_mqtt_ref .
 
-wbs:Effluent_Pump-out-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-speed-command a s223:QuantifiableActuatableProperty ;
     qudt:hasQuantityKind qudtqk:SpeedRatio ;
     qudt:hasUnit unit:PERCENT ;
-    acq:hasExternalReference wbs:Effluent_Pump-speed-command_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-speed-command_mqtt_ref .
 
-wbs:Effluent_Pump-speed-command_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-speed-command" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-speed-command_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-speed-command" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Effluent_Pump-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Effluent_Pump-status_mqtt_ref .
+    ref:hasExternalReference wbs:Effluent_Pump-status_mqtt_ref .
 
-wbs:Effluent_Pump-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-bacteria-enterococcus a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Bacteria ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:CFU-PER-100ML ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-bacteria-enterococcus_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-bacteria-enterococcus_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-bacteria-enterococcus_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-bacteria-enterococcus" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-bacteria-enterococcus_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-bacteria-enterococcus" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-biochemical-oxygen-demand a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Oxygen ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-biochemical-oxygen-demand_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-biochemical-oxygen-demand_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-biochemical-oxygen-demand_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-biochemical-oxygen-demand" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-biochemical-oxygen-demand_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-biochemical-oxygen-demand" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-cl2-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-cl2-mgL_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-copper a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Metals ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-copper_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-copper_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-copper_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-copper" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-copper_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-copper" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-cyanide a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Cyanide ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-cyanide_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-cyanide_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-cyanide_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-cyanide" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-cyanide_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-cyanide" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-flow-rate_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-nh4-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Ammonia ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-nh4-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-nh4-mgL_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-nh4-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-nh4-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-nh4-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-nh4-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-ph_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-pressure_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-teq-dioxin a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Organics ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-teq-dioxin_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-teq-dioxin_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-teq-dioxin_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-teq-dioxin" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-teq-dioxin_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-teq-dioxin" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-in-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-in-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-in-tss-concentration_mqtt_ref .
 
-wbs:Flow_Return_Pump1-in-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-in-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-in-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-in-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-out-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-out-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-out-flow-rate_mqtt_ref .
 
-wbs:Flow_Return_Pump1-out-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-out-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-out-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-out-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-out-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-out-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-out-pressure_mqtt_ref .
 
-wbs:Flow_Return_Pump1-out-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-out-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-out-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-out-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-speed-command a s223:QuantifiableActuatableProperty ;
     qudt:hasQuantityKind qudtqk:SpeedRatio ;
     qudt:hasUnit unit:PERCENT ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-speed-command_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-speed-command_mqtt_ref .
 
-wbs:Flow_Return_Pump1-speed-command_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-speed-command" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-speed-command_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-speed-command" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump1-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Flow_Return_Pump1-status_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump1-status_mqtt_ref .
 
-wbs:Flow_Return_Pump1-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump1-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump1-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump1-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump2-in-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Flow_Return_Pump2-in-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump2-in-flow-rate_mqtt_ref .
 
-wbs:Flow_Return_Pump2-in-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump2-in-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump2-in-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump2-in-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump2-in-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Flow_Return_Pump2-in-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump2-in-pressure_mqtt_ref .
 
-wbs:Flow_Return_Pump2-in-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump2-in-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump2-in-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump2-in-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump2-out-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Flow_Return_Pump2-out-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump2-out-flow-rate_mqtt_ref .
 
-wbs:Flow_Return_Pump2-out-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump2-out-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump2-out-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump2-out-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump2-out-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Flow_Return_Pump2-out-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump2-out-pressure_mqtt_ref .
 
-wbs:Flow_Return_Pump2-out-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump2-out-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump2-out-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump2-out-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump2-speed-command a s223:QuantifiableActuatableProperty ;
     qudt:hasQuantityKind qudtqk:SpeedRatio ;
     qudt:hasUnit unit:PERCENT ;
-    acq:hasExternalReference wbs:Flow_Return_Pump2-speed-command_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump2-speed-command_mqtt_ref .
 
-wbs:Flow_Return_Pump2-speed-command_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump2-speed-command" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump2-speed-command_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump2-speed-command" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Flow_Return_Pump2-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Flow_Return_Pump2-status_mqtt_ref .
+    ref:hasExternalReference wbs:Flow_Return_Pump2-status_mqtt_ref .
 
-wbs:Flow_Return_Pump2-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Flow_Return_Pump2-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Flow_Return_Pump2-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Flow_Return_Pump2-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Grinder-electric-current a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:ElectricCurrent ;
     qudt:hasUnit unit:A ;
-    acq:hasExternalReference wbs:Grinder-electric-current_mqtt_ref .
+    ref:hasExternalReference wbs:Grinder-electric-current_mqtt_ref .
 
-wbs:Grinder-electric-current_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Grinder-electric-current" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Grinder-electric-current_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Grinder-electric-current" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Grinder-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Grinder-status_mqtt_ref .
+    ref:hasExternalReference wbs:Grinder-status_mqtt_ref .
 
-wbs:Grinder-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Grinder-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Grinder-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Grinder-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump a nawi:Pump ;
     s223:cnx wbs:Influent_Pump-out ;
@@ -780,502 +721,462 @@ wbs:Influent_Pump-in-bacteria-enterococcus a s223:QuantifiableObservableProperty
     s223:ofSubstance nawi:Constituent-Bacteria ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:CFU-PER-100ML ;
-    acq:hasExternalReference wbs:Influent_Pump-in-bacteria-enterococcus_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-bacteria-enterococcus_mqtt_ref .
 
-wbs:Influent_Pump-in-bacteria-enterococcus_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-bacteria-enterococcus" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-bacteria-enterococcus_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-bacteria-enterococcus" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-biochemical-oxygen-demand a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Oxygen ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref .
 
-wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-biochemical-oxygen-demand" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-biochemical-oxygen-demand" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-cl2-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-cl2-mgL_mqtt_ref .
 
-wbs:Influent_Pump-in-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-copper a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Metals ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-copper_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-copper_mqtt_ref .
 
-wbs:Influent_Pump-in-copper_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-copper" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-copper_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-copper" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-cyanide a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Cyanide ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-cyanide_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-cyanide_mqtt_ref .
 
-wbs:Influent_Pump-in-cyanide_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-cyanide" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-cyanide_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-cyanide" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Influent_Pump-in-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-flow-rate_mqtt_ref .
 
-wbs:Influent_Pump-in-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-nh4-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Ammonia ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-nh4-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-nh4-mgL_mqtt_ref .
 
-wbs:Influent_Pump-in-nh4-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-nh4-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-nh4-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-nh4-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Influent_Pump-in-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-ph_mqtt_ref .
 
-wbs:Influent_Pump-in-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Influent_Pump-in-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-pressure_mqtt_ref .
 
-wbs:Influent_Pump-in-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-teq-dioxin a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Organics ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-teq-dioxin_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-teq-dioxin_mqtt_ref .
 
-wbs:Influent_Pump-in-teq-dioxin_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-teq-dioxin" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-teq-dioxin_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-teq-dioxin" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-in-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-in-tss-concentration_mqtt_ref .
 
-wbs:Influent_Pump-in-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-bacteria-enterococcus a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Bacteria ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:CFU-PER-100ML ;
-    acq:hasExternalReference wbs:Influent_Pump-out-bacteria-enterococcus_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-bacteria-enterococcus_mqtt_ref .
 
-wbs:Influent_Pump-out-bacteria-enterococcus_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-bacteria-enterococcus" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-bacteria-enterococcus_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-bacteria-enterococcus" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-biochemical-oxygen-demand a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Oxygen ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-out-biochemical-oxygen-demand_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-biochemical-oxygen-demand_mqtt_ref .
 
-wbs:Influent_Pump-out-biochemical-oxygen-demand_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-biochemical-oxygen-demand" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-biochemical-oxygen-demand_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-biochemical-oxygen-demand" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-out-cl2-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-cl2-mgL_mqtt_ref .
 
-wbs:Influent_Pump-out-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-copper a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Metals ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-out-copper_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-copper_mqtt_ref .
 
-wbs:Influent_Pump-out-copper_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-copper" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-copper_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-copper" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-cyanide a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Cyanide ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-out-cyanide_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-cyanide_mqtt_ref .
 
-wbs:Influent_Pump-out-cyanide_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-cyanide" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-cyanide_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-cyanide" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Influent_Pump-out-flow-rate_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-flow-rate_mqtt_ref .
 
-wbs:Influent_Pump-out-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-nh4-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Ammonia ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-out-nh4-mgL_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-nh4-mgL_mqtt_ref .
 
-wbs:Influent_Pump-out-nh4-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-nh4-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-nh4-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-nh4-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Influent_Pump-out-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-ph_mqtt_ref .
 
-wbs:Influent_Pump-out-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    acq:hasExternalReference wbs:Influent_Pump-out-pressure_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-pressure_mqtt_ref .
 
-wbs:Influent_Pump-out-pressure_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-pressure" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-pressure" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-teq-dioxin a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Organics ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-out-teq-dioxin_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-teq-dioxin_mqtt_ref .
 
-wbs:Influent_Pump-out-teq-dioxin_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-teq-dioxin" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-teq-dioxin_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-teq-dioxin" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-out-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-out-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-out-tss-concentration_mqtt_ref .
 
-wbs:Influent_Pump-out-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-out-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-out-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-out-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-speed-command a s223:QuantifiableActuatableProperty ;
     qudt:hasQuantityKind qudtqk:SpeedRatio ;
     qudt:hasUnit unit:PERCENT ;
-    acq:hasExternalReference wbs:Influent_Pump-speed-command_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-speed-command_mqtt_ref .
 
-wbs:Influent_Pump-speed-command_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-speed-command" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-speed-command_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-speed-command" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Influent_Pump-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Influent_Pump-status_mqtt_ref .
+    ref:hasExternalReference wbs:Influent_Pump-status_mqtt_ref .
 
-wbs:Influent_Pump-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Primary_Sedimentation-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Primary_Sedimentation-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Primary_Sedimentation-ph_mqtt_ref .
 
-wbs:Primary_Sedimentation-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Primary_Sedimentation-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Primary_Sedimentation-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Primary_Sedimentation-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Primary_Sedimentation-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    acq:hasExternalReference wbs:Primary_Sedimentation-temperature_mqtt_ref .
+    ref:hasExternalReference wbs:Primary_Sedimentation-temperature_mqtt_ref .
 
-wbs:Primary_Sedimentation-temperature_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Primary_Sedimentation-temperature" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Primary_Sedimentation-temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Primary_Sedimentation-temperature" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Primary_Sedimentation-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Primary_Sedimentation-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:Primary_Sedimentation-tss-concentration_mqtt_ref .
 
-wbs:Primary_Sedimentation-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Primary_Sedimentation-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Primary_Sedimentation-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Primary_Sedimentation-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Primary_Sedimentation-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:Primary_Sedimentation-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:Primary_Sedimentation-turbidity_mqtt_ref .
 
-wbs:Primary_Sedimentation-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Primary_Sedimentation-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Primary_Sedimentation-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Primary_Sedimentation-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Primary_Sedimentation-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:Primary_Sedimentation-volume_mqtt_ref .
+    ref:hasExternalReference wbs:Primary_Sedimentation-volume_mqtt_ref .
 
-wbs:Primary_Sedimentation-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Primary_Sedimentation-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Primary_Sedimentation-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Primary_Sedimentation-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:RBC_Secondary_Sedimentation-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:RBC_Secondary_Sedimentation-ph_mqtt_ref .
+    ref:hasExternalReference wbs:RBC_Secondary_Sedimentation-ph_mqtt_ref .
 
-wbs:RBC_Secondary_Sedimentation-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/RBC_Secondary_Sedimentation-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:RBC_Secondary_Sedimentation-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/RBC_Secondary_Sedimentation-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:RBC_Secondary_Sedimentation-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    acq:hasExternalReference wbs:RBC_Secondary_Sedimentation-temperature_mqtt_ref .
+    ref:hasExternalReference wbs:RBC_Secondary_Sedimentation-temperature_mqtt_ref .
 
-wbs:RBC_Secondary_Sedimentation-temperature_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/RBC_Secondary_Sedimentation-temperature" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:RBC_Secondary_Sedimentation-temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/RBC_Secondary_Sedimentation-temperature" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:RBC_Secondary_Sedimentation-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:RBC_Secondary_Sedimentation-tss-concentration_mqtt_ref .
+    ref:hasExternalReference wbs:RBC_Secondary_Sedimentation-tss-concentration_mqtt_ref .
 
-wbs:RBC_Secondary_Sedimentation-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/RBC_Secondary_Sedimentation-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:RBC_Secondary_Sedimentation-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/RBC_Secondary_Sedimentation-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:RBC_Secondary_Sedimentation-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:RBC_Secondary_Sedimentation-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:RBC_Secondary_Sedimentation-turbidity_mqtt_ref .
 
-wbs:RBC_Secondary_Sedimentation-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/RBC_Secondary_Sedimentation-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:RBC_Secondary_Sedimentation-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/RBC_Secondary_Sedimentation-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:RBC_Secondary_Sedimentation-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref .
+    ref:hasExternalReference wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref .
 
-wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/RBC_Secondary_Sedimentation-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/RBC_Secondary_Sedimentation-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Sluice_Gate-opening-command a s223:QuantifiableActuatableProperty ;
     qudt:hasQuantityKind qudtqk:OpeningRatio ;
-    acq:hasExternalReference wbs:Sluice_Gate-opening-command_mqtt_ref .
+    ref:hasExternalReference wbs:Sluice_Gate-opening-command_mqtt_ref .
 
-wbs:Sluice_Gate-opening-command_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Sluice_Gate-opening-command" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Sluice_Gate-opening-command_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Sluice_Gate-opening-command" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Sluice_Gate-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Sluice_Gate-status_mqtt_ref .
+    ref:hasExternalReference wbs:Sluice_Gate-status_mqtt_ref .
 
-wbs:Sluice_Gate-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Sluice_Gate-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Sluice_Gate-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Sluice_Gate-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Storage_Basin-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Storage_Basin-ph_mqtt_ref .
+    ref:hasExternalReference wbs:Storage_Basin-ph_mqtt_ref .
 
-wbs:Storage_Basin-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Storage_Basin-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Storage_Basin-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Storage_Basin-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Storage_Basin-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    acq:hasExternalReference wbs:Storage_Basin-temperature_mqtt_ref .
+    ref:hasExternalReference wbs:Storage_Basin-temperature_mqtt_ref .
 
-wbs:Storage_Basin-temperature_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Storage_Basin-temperature" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Storage_Basin-temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Storage_Basin-temperature" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Storage_Basin-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:Storage_Basin-turbidity_mqtt_ref .
+    ref:hasExternalReference wbs:Storage_Basin-turbidity_mqtt_ref .
 
-wbs:Storage_Basin-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Storage_Basin-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Storage_Basin-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Storage_Basin-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Storage_Basin-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:Storage_Basin-volume_mqtt_ref .
+    ref:hasExternalReference wbs:Storage_Basin-volume_mqtt_ref .
 
-wbs:Storage_Basin-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Storage_Basin-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Storage_Basin-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Storage_Basin-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 wbs:Wet_Weather_Screen a nawi:Screen ;
     s223:cnx wbs:Wet_Weather_Screen-in,

--- a/deployments/BENICIA/benicia-model-with-refs-thresholds.ttl
+++ b/deployments/BENICIA/benicia-model-with-refs-thresholds.ttl
@@ -1,4 +1,5 @@
 @prefix acq: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix nawi: <urn:nawi-water-ontology#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -27,105 +28,100 @@ wbs:AS_Aeration_Basin-mlss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref,
+    ref:hasExternalReference wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref,
         wbs:AS_Aeration_Basin-mlss-concentration_parquet_ref .
 
-wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-mlss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-mlss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-mlss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:AS_Aeration_Basin-mlss-concentration_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/AS_Aeration_Basin-mlss-concentration.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/AS_Aeration_Basin-mlss-concentration.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:AS_Aeration_Basin-mlss-concentration_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/AS_Aeration_Basin-mlss-concentration.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/AS_Aeration_Basin-mlss-concentration.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:AS_Aeration_Basin-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:AS_Aeration_Basin-volume_mqtt_ref,
+    ref:hasExternalReference wbs:AS_Aeration_Basin-volume_mqtt_ref,
         wbs:AS_Aeration_Basin-volume_parquet_ref .
 
-wbs:AS_Aeration_Basin-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Aeration_Basin-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Aeration_Basin-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Aeration_Basin-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:AS_Aeration_Basin-volume_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/AS_Aeration_Basin-volume.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/AS_Aeration_Basin-volume.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:AS_Aeration_Basin-volume_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/AS_Aeration_Basin-volume.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/AS_Aeration_Basin-volume.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:AS_Secondary_Sedimentation-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:AS_Secondary_Sedimentation-volume_mqtt_ref,
+    ref:hasExternalReference wbs:AS_Secondary_Sedimentation-volume_mqtt_ref,
         wbs:AS_Secondary_Sedimentation-volume_parquet_ref .
 
-wbs:AS_Secondary_Sedimentation-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/AS_Secondary_Sedimentation-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:AS_Secondary_Sedimentation-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/AS_Secondary_Sedimentation-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:AS_Secondary_Sedimentation-volume_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/AS_Secondary_Sedimentation-volume.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/AS_Secondary_Sedimentation-volume.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:AS_Secondary_Sedimentation-volume_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/AS_Secondary_Sedimentation-volume.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/AS_Secondary_Sedimentation-volume.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Chlorination_Basin-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Chlorination_Basin-cl2-mgL_mqtt_ref,
+    ref:hasExternalReference wbs:Chlorination_Basin-cl2-mgL_mqtt_ref,
         wbs:Chlorination_Basin-cl2-mgL_parquet_ref .
 
-wbs:Chlorination_Basin-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Chlorination_Basin-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Chlorination_Basin-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Chlorination_Basin-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Chlorination_Basin-cl2-mgL_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Chlorination_Basin-cl2-mgL.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Chlorination_Basin-cl2-mgL.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Chlorination_Basin-cl2-mgL_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Chlorination_Basin-cl2-mgL.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Chlorination_Basin-cl2-mgL.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Chlorination_Basin-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:Chlorination_Basin-volume_mqtt_ref,
+    ref:hasExternalReference wbs:Chlorination_Basin-volume_mqtt_ref,
         wbs:Chlorination_Basin-volume_parquet_ref .
 
-wbs:Chlorination_Basin-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Chlorination_Basin-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Chlorination_Basin-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Chlorination_Basin-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Chlorination_Basin-volume_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Chlorination_Basin-volume.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Chlorination_Basin-volume.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Chlorination_Basin-volume_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Chlorination_Basin-volume.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Chlorination_Basin-volume.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-bacteria-enterococcus a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Constituent-Bacteria ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:CFU-PER-100ML ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref,
         wbs:Effluent_Pump-out-bacteria-enterococcus_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-bacteria-enterococcus_threshold .
 
@@ -152,18 +148,17 @@ wbs:Effluent_Pump-out-bacteria-enterococcus_limit_3 a acq:Limit ;
     acq:unit unit:CFU-PER-100ML ;
     acq:value 1000 .
 
-wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-bacteria-enterococcus" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-bacteria-enterococcus_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-bacteria-enterococcus" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-bacteria-enterococcus_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-bacteria-enterococcus.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-bacteria-enterococcus.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-bacteria-enterococcus_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-bacteria-enterococcus.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-bacteria-enterococcus.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-bacteria-enterococcus_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-bacteria-enterococcus_limit_1,
@@ -186,18 +181,17 @@ wbs:Effluent_Pump-out-biochemical-oxygen-demand_limit_2 a acq:Limit ;
     acq:unit unit:MilliGM-PER-L ;
     acq:value 45 .
 
-wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-biochemical-oxygen-demand" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-biochemical-oxygen-demand" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-biochemical-oxygen-demand_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-biochemical-oxygen-demand.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-biochemical-oxygen-demand.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-biochemical-oxygen-demand_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-biochemical-oxygen-demand.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-biochemical-oxygen-demand.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-biochemical-oxygen-demand_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-biochemical-oxygen-demand_limit_1,
@@ -209,7 +203,7 @@ wbs:Effluent_Pump-out-cl2-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Chlorine ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref,
         wbs:Effluent_Pump-out-cl2-mgL_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-cl2-mgL_threshold .
 
@@ -229,18 +223,17 @@ wbs:Effluent_Pump-out-cl2-mgL_limit_2 a acq:Limit ;
     acq:unit unit:MilliGM-PER-L ;
     acq:value 0e+00 .
 
-wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-cl2-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-cl2-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-cl2-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-cl2-mgL_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-cl2-mgL.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-cl2-mgL.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-cl2-mgL_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-cl2-mgL.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-cl2-mgL.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-cl2-mgL_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-cl2-mgL_limit_1,
@@ -253,7 +246,7 @@ wbs:Effluent_Pump-out-copper a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Constituent-Metals ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-copper_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-copper_mqtt_ref,
         wbs:Effluent_Pump-out-copper_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-copper_threshold .
 
@@ -271,18 +264,17 @@ wbs:Effluent_Pump-out-copper_limit_2 a acq:Limit ;
     acq:unit unit:MicroGM-PER-L ;
     acq:value 119 .
 
-wbs:Effluent_Pump-out-copper_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-copper" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-copper_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-copper" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-copper_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-copper.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-copper.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-copper_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-copper.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-copper.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-copper_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-copper_limit_1,
@@ -295,7 +287,7 @@ wbs:Effluent_Pump-out-cyanide a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Constituent-Cyanide ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-cyanide_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-cyanide_mqtt_ref,
         wbs:Effluent_Pump-out-cyanide_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-cyanide_threshold .
 
@@ -313,18 +305,17 @@ wbs:Effluent_Pump-out-cyanide_limit_2 a acq:Limit ;
     acq:unit unit:MicroGM-PER-L ;
     acq:value 43 .
 
-wbs:Effluent_Pump-out-cyanide_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-cyanide" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-cyanide_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-cyanide" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-cyanide_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-cyanide.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-cyanide.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-cyanide_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-cyanide.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-cyanide.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-cyanide_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-cyanide_limit_1,
@@ -335,22 +326,21 @@ wbs:Effluent_Pump-out-cyanide_threshold a acq:Threshold ;
 wbs:Effluent_Pump-out-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
     qudt:hasUnit unit:GAL_US-PER-MIN ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-flow-rate_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-flow-rate_mqtt_ref,
         wbs:Effluent_Pump-out-flow-rate_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-flow-rate_threshold .
 
-wbs:Effluent_Pump-out-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-flow-rate_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-flow-rate.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-flow-rate.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-flow-rate_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-flow-rate.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-flow-rate.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-flow-rate_threshold a acq:Threshold ;
     acq:monitoring_location "EFF-001" ;
@@ -361,7 +351,7 @@ wbs:Effluent_Pump-out-nh4-mgL a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Ammonia ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref,
         wbs:Effluent_Pump-out-nh4-mgL_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-nh4-mgL_threshold .
 
@@ -379,18 +369,17 @@ wbs:Effluent_Pump-out-nh4-mgL_limit_2 a acq:Limit ;
     acq:unit unit:MilliGM-PER-L ;
     acq:value 110 .
 
-wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-nh4-mgL" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-nh4-mgL_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-nh4-mgL" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-nh4-mgL_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-nh4-mgL.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-nh4-mgL.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-nh4-mgL_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-nh4-mgL.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-nh4-mgL.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-nh4-mgL_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-nh4-mgL_limit_1,
@@ -401,7 +390,7 @@ wbs:Effluent_Pump-out-nh4-mgL_threshold a acq:Threshold ;
 wbs:Effluent_Pump-out-ph a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Acidity ;
     qudt:hasUnit unit:PH ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-ph_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-ph_mqtt_ref,
         wbs:Effluent_Pump-out-ph_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-ph_threshold .
 
@@ -419,18 +408,17 @@ wbs:Effluent_Pump-out-ph_limit_2 a acq:Limit ;
     acq:unit unit:PH ;
     acq:value 9e+00 .
 
-wbs:Effluent_Pump-out-ph_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-ph" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-ph_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-ph" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-ph_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-ph.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-ph.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-ph_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-ph.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-ph.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-ph_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-ph_limit_1,
@@ -443,7 +431,7 @@ wbs:Effluent_Pump-out-teq-dioxin a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Constituent-Organics ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref,
         wbs:Effluent_Pump-out-teq-dioxin_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-teq-dioxin_threshold .
 
@@ -461,18 +449,17 @@ wbs:Effluent_Pump-out-teq-dioxin_limit_2 a acq:Limit ;
     acq:unit unit:MicroGM-PER-L ;
     acq:value 2.8e-08 .
 
-wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-teq-dioxin" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-teq-dioxin_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-teq-dioxin" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-teq-dioxin_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-teq-dioxin.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-teq-dioxin.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-teq-dioxin_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-teq-dioxin.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-teq-dioxin.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-teq-dioxin_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-teq-dioxin_limit_1,
@@ -494,18 +481,17 @@ wbs:Effluent_Pump-out-tss-concentration_limit_2 a acq:Limit ;
     acq:unit unit:MilliGM-PER-L ;
     acq:value 45 .
 
-wbs:Effluent_Pump-out-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-out-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-out-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-out-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-out-tss-concentration_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-out-tss-concentration.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-out-tss-concentration.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-out-tss-concentration_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-out-tss-concentration.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-out-tss-concentration.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Effluent_Pump-out-tss-concentration_threshold a acq:Threshold ;
     acq:hasLimit wbs:Effluent_Pump-out-tss-concentration_limit_1,
@@ -516,40 +502,38 @@ wbs:Effluent_Pump-out-tss-concentration_threshold a acq:Threshold ;
 wbs:Effluent_Pump-speed-command a s223:QuantifiableActuatableProperty ;
     qudt:hasQuantityKind qudtqk:SpeedRatio ;
     qudt:hasUnit unit:PERCENT ;
-    acq:hasExternalReference wbs:Effluent_Pump-speed-command_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-speed-command_mqtt_ref,
         wbs:Effluent_Pump-speed-command_parquet_ref .
 
-wbs:Effluent_Pump-speed-command_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Effluent_Pump-speed-command" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Effluent_Pump-speed-command_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Effluent_Pump-speed-command" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Effluent_Pump-speed-command_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Effluent_Pump-speed-command.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Effluent_Pump-speed-command.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Effluent_Pump-speed-command_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Effluent_Pump-speed-command.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Effluent_Pump-speed-command.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Grinder-electric-current a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:ElectricCurrent ;
     qudt:hasUnit unit:A ;
-    acq:hasExternalReference wbs:Grinder-electric-current_mqtt_ref,
+    ref:hasExternalReference wbs:Grinder-electric-current_mqtt_ref,
         wbs:Grinder-electric-current_parquet_ref .
 
-wbs:Grinder-electric-current_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Grinder-electric-current" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Grinder-electric-current_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Grinder-electric-current" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Grinder-electric-current_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Grinder-electric-current.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Grinder-electric-current.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Grinder-electric-current_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Grinder-electric-current.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Grinder-electric-current.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Influent_Pump a nawi:Pump ;
     s223:cnx wbs:Influent_Pump-out ;
@@ -567,18 +551,17 @@ wbs:Influent_Pump-in a s223:InletConnectionPoint ;
         wbs:Influent_Pump-in-flow-rate,
         wbs:Influent_Pump-in-tss-concentration .
 
-wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-biochemical-oxygen-demand" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-biochemical-oxygen-demand" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Influent_Pump-in-biochemical-oxygen-demand_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Influent_Pump-in-biochemical-oxygen-demand.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Influent_Pump-in-biochemical-oxygen-demand.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Influent_Pump-in-biochemical-oxygen-demand_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Influent_Pump-in-biochemical-oxygen-demand.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Influent_Pump-in-biochemical-oxygen-demand.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Influent_Pump-in-biochemical-oxygen-demand_threshold a acq:Threshold ;
     acq:monitoring_location "INF-001" ;
@@ -590,7 +573,7 @@ wbs:Influent_Pump-in-cyanide a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Constituent-Cyanide ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MicroGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-cyanide_mqtt_ref,
+    ref:hasExternalReference wbs:Influent_Pump-in-cyanide_mqtt_ref,
         wbs:Influent_Pump-in-cyanide_parquet_ref ;
     acq:hasThreshold wbs:Influent_Pump-in-cyanide_threshold .
 
@@ -602,18 +585,17 @@ wbs:Influent_Pump-in-cyanide_limit_1 a acq:Limit ;
     acq:unit unit:MicroGM-PER-L ;
     acq:value 6.6e+00 .
 
-wbs:Influent_Pump-in-cyanide_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-cyanide" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-cyanide_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-cyanide" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Influent_Pump-in-cyanide_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Influent_Pump-in-cyanide.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Influent_Pump-in-cyanide.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Influent_Pump-in-cyanide_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Influent_Pump-in-cyanide.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Influent_Pump-in-cyanide.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Influent_Pump-in-cyanide_threshold a acq:Threshold ;
     acq:hasLimit wbs:Influent_Pump-in-cyanide_limit_1 ;
@@ -622,7 +604,7 @@ wbs:Influent_Pump-in-cyanide_threshold a acq:Threshold ;
 
 wbs:Influent_Pump-in-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
-    acq:hasExternalReference wbs:Influent_Pump-in-flow-rate_mqtt_ref,
+    ref:hasExternalReference wbs:Influent_Pump-in-flow-rate_mqtt_ref,
         wbs:Influent_Pump-in-flow-rate_parquet_ref ;
     acq:hasThreshold wbs:Influent_Pump-in-flow-rate_threshold .
 
@@ -636,36 +618,34 @@ wbs:Influent_Pump-in-flow-rate_limit_1 a acq:Limit ;
     acq:unit unit:GAL_US-PER-DAY ;
     acq:value 4.5e+06 .
 
-wbs:Influent_Pump-in-flow-rate_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-flow-rate" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-flow-rate_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-flow-rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Influent_Pump-in-flow-rate_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Influent_Pump-in-flow-rate.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Influent_Pump-in-flow-rate.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Influent_Pump-in-flow-rate_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Influent_Pump-in-flow-rate.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Influent_Pump-in-flow-rate.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Influent_Pump-in-flow-rate_threshold a acq:Threshold ;
     acq:hasLimit wbs:Influent_Pump-in-flow-rate_limit_1 ;
     acq:monitoring_location "INF-001" ;
     acq:side "influent" .
 
-wbs:Influent_Pump-in-tss-concentration_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-in-tss-concentration" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-in-tss-concentration_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-in-tss-concentration" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Influent_Pump-in-tss-concentration_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Influent_Pump-in-tss-concentration.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Influent_Pump-in-tss-concentration.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Influent_Pump-in-tss-concentration_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Influent_Pump-in-tss-concentration.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Influent_Pump-in-tss-concentration.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Influent_Pump-in-tss-concentration_threshold a acq:Threshold ;
     acq:monitoring_location "INF-001" ;
@@ -674,133 +654,126 @@ wbs:Influent_Pump-in-tss-concentration_threshold a acq:Threshold ;
 
 wbs:Influent_Pump-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Influent_Pump-status_mqtt_ref,
+    ref:hasExternalReference wbs:Influent_Pump-status_mqtt_ref,
         wbs:Influent_Pump-status_parquet_ref .
 
-wbs:Influent_Pump-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Influent_Pump-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Influent_Pump-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Influent_Pump-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Influent_Pump-status_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Influent_Pump-status.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Influent_Pump-status.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Influent_Pump-status_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Influent_Pump-status.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Influent_Pump-status.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Primary_Sedimentation-turbidity a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Turbidity ;
     qudt:hasUnit unit:NTU ;
-    acq:hasExternalReference wbs:Primary_Sedimentation-turbidity_mqtt_ref,
+    ref:hasExternalReference wbs:Primary_Sedimentation-turbidity_mqtt_ref,
         wbs:Primary_Sedimentation-turbidity_parquet_ref .
 
-wbs:Primary_Sedimentation-turbidity_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Primary_Sedimentation-turbidity" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Primary_Sedimentation-turbidity_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Primary_Sedimentation-turbidity" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Primary_Sedimentation-turbidity_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Primary_Sedimentation-turbidity.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Primary_Sedimentation-turbidity.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Primary_Sedimentation-turbidity_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Primary_Sedimentation-turbidity.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Primary_Sedimentation-turbidity.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Primary_Sedimentation-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:Primary_Sedimentation-volume_mqtt_ref,
+    ref:hasExternalReference wbs:Primary_Sedimentation-volume_mqtt_ref,
         wbs:Primary_Sedimentation-volume_parquet_ref .
 
-wbs:Primary_Sedimentation-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Primary_Sedimentation-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Primary_Sedimentation-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Primary_Sedimentation-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Primary_Sedimentation-volume_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Primary_Sedimentation-volume.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Primary_Sedimentation-volume.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Primary_Sedimentation-volume_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Primary_Sedimentation-volume.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Primary_Sedimentation-volume.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:RBC_Secondary_Sedimentation-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref,
+    ref:hasExternalReference wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref,
         wbs:RBC_Secondary_Sedimentation-volume_parquet_ref .
 
-wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/RBC_Secondary_Sedimentation-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:RBC_Secondary_Sedimentation-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/RBC_Secondary_Sedimentation-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:RBC_Secondary_Sedimentation-volume_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/RBC_Secondary_Sedimentation-volume.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/RBC_Secondary_Sedimentation-volume.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:RBC_Secondary_Sedimentation-volume_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/RBC_Secondary_Sedimentation-volume.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/RBC_Secondary_Sedimentation-volume.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Sluice_Gate-opening-command a s223:QuantifiableActuatableProperty ;
     qudt:hasQuantityKind qudtqk:OpeningRatio ;
-    acq:hasExternalReference wbs:Sluice_Gate-opening-command_mqtt_ref,
+    ref:hasExternalReference wbs:Sluice_Gate-opening-command_mqtt_ref,
         wbs:Sluice_Gate-opening-command_parquet_ref .
 
-wbs:Sluice_Gate-opening-command_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Sluice_Gate-opening-command" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Sluice_Gate-opening-command_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Sluice_Gate-opening-command" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Sluice_Gate-opening-command_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Sluice_Gate-opening-command.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Sluice_Gate-opening-command.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Sluice_Gate-opening-command_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Sluice_Gate-opening-command.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Sluice_Gate-opening-command.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Sluice_Gate-status a s223:QuantifiableObservableProperty ;
     qudt:hasEnumerationKind s223:EnumerationKind-Status ;
-    acq:hasExternalReference wbs:Sluice_Gate-status_mqtt_ref,
+    ref:hasExternalReference wbs:Sluice_Gate-status_mqtt_ref,
         wbs:Sluice_Gate-status_parquet_ref .
 
-wbs:Sluice_Gate-status_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Sluice_Gate-status" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Sluice_Gate-status_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Sluice_Gate-status" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Sluice_Gate-status_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Sluice_Gate-status.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Sluice_Gate-status.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Sluice_Gate-status_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Sluice_Gate-status.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Sluice_Gate-status.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Storage_Basin-volume a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference wbs:Storage_Basin-volume_mqtt_ref,
+    ref:hasExternalReference wbs:Storage_Basin-volume_mqtt_ref,
         wbs:Storage_Basin-volume_parquet_ref .
 
-wbs:Storage_Basin-volume_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:Port 1883 ;
-    acq:Topic "benicia/Storage_Basin-volume" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+wbs:Storage_Basin-volume_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "benicia/Storage_Basin-volume" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-wbs:Storage_Basin-volume_parquet_ref a acq:ParquetReference ;
-    acq:DataSource "data/BENICIA/parquet/Storage_Basin-volume.parquet" ;
-    acq:hasFilePath "data/BENICIA/parquet/Storage_Basin-volume.parquet" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+wbs:Storage_Basin-volume_parquet_ref a ref:FileReference ;
+    acq:dataSource "data/BENICIA/parquet/Storage_Basin-volume.parquet" ;
+    ref:fileLocation "data/BENICIA/parquet/Storage_Basin-volume.parquet" ;
+    ref:timeColumnID 0 ;
+    ref:valueColumnID 1 .
 
 wbs:Wet_Weather_Screen a nawi:Screen ;
     s223:cnx wbs:Wet_Weather_Screen-in,
@@ -820,7 +793,7 @@ wbs:Effluent_Pump-out-biochemical-oxygen-demand a s223:QuantifiableObservablePro
     s223:ofSubstance nawi:Oxygen ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-biochemical-oxygen-demand_mqtt_ref,
         wbs:Effluent_Pump-out-biochemical-oxygen-demand_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-biochemical-oxygen-demand_threshold .
 
@@ -829,7 +802,7 @@ wbs:Effluent_Pump-out-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Effluent_Pump-out-tss-concentration_mqtt_ref,
+    ref:hasExternalReference wbs:Effluent_Pump-out-tss-concentration_mqtt_ref,
         wbs:Effluent_Pump-out-tss-concentration_parquet_ref ;
     acq:hasThreshold wbs:Effluent_Pump-out-tss-concentration_threshold .
 
@@ -838,7 +811,7 @@ wbs:Influent_Pump-in-biochemical-oxygen-demand a s223:QuantifiableObservableProp
     s223:ofSubstance nawi:Oxygen ;
     qudt:hasQuantityKind qudtqk:Concentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref,
+    ref:hasExternalReference wbs:Influent_Pump-in-biochemical-oxygen-demand_mqtt_ref,
         wbs:Influent_Pump-in-biochemical-oxygen-demand_parquet_ref ;
     acq:hasThreshold wbs:Influent_Pump-in-biochemical-oxygen-demand_threshold .
 
@@ -847,7 +820,7 @@ wbs:Influent_Pump-in-tss-concentration a s223:QuantifiableObservableProperty ;
     s223:ofSubstance s223:Solids-SuspendedSolids ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:MilliGM-PER-L ;
-    acq:hasExternalReference wbs:Influent_Pump-in-tss-concentration_mqtt_ref,
+    ref:hasExternalReference wbs:Influent_Pump-in-tss-concentration_mqtt_ref,
         wbs:Influent_Pump-in-tss-concentration_parquet_ref ;
     acq:hasThreshold wbs:Influent_Pump-in-tss-concentration_threshold .
 

--- a/deployments/BENICIA/scripts/add_external_refs_and_thresholds.py
+++ b/deployments/BENICIA/scripts/add_external_refs_and_thresholds.py
@@ -5,7 +5,23 @@ import rdflib
 from rdflib import Literal
 from rdflib.namespace import RDF, XSD
 
-from acquirium.internals.internals_namespaces import ACQUIRIUM_NS, QUDT_UNIT, S223
+from acquirium.internals.internals_namespaces import (
+    ACQUIRIUM_NS,
+    BRICK_REF,
+    DATA_SOURCE,
+    FILE_LOCATION,
+    FILE_REFERENCE,
+    HAS_EXTERNAL_REFERENCE,
+    MQTT_BROKER,
+    MQTT_REFERENCE,
+    MQTT_TOPIC,
+    QUDT_UNIT,
+    S223,
+    TIME_COLUMN_ID,
+    TIME_KEY,
+    VALUE_COLUMN_ID,
+    VALUE_KEY,
+)
 
 
 PROPERTY_TYPES = {
@@ -309,33 +325,34 @@ def add_external_references(
     broker: str,
     port: int,
     topic_prefix: str,
-    time_col: int,
-    value_col: int,
+    time_col: str,
+    value_col: str,
 ) -> None:
     wbs = rdflib.Namespace("urn:ex/")
+    broker_literal = f"{broker}:{port}" if port else broker
 
     for prop in properties:
         name = local_name(prop)
-        parquet_ref = wbs[f"{name}_parquet_ref"]
+        file_ref = wbs[f"{name}_file_ref"]
         mqtt_ref = wbs[f"{name}_mqtt_ref"]
 
-        graph.add((prop, ACQUIRIUM_NS.hasExternalReference, parquet_ref))
-        graph.add((prop, ACQUIRIUM_NS.hasExternalReference, mqtt_ref))
+        graph.add((prop, HAS_EXTERNAL_REFERENCE, file_ref))
+        graph.add((prop, HAS_EXTERNAL_REFERENCE, mqtt_ref))
 
         file_path = str(parquet_dir / f"{name}.parquet")
 
-        graph.add((parquet_ref, RDF.type, ACQUIRIUM_NS.ParquetReference))
-        graph.add((parquet_ref, ACQUIRIUM_NS.DataSource, Literal(file_path)))
-        graph.add((parquet_ref, ACQUIRIUM_NS.hasFilePath, Literal(file_path)))
-        graph.add((parquet_ref, ACQUIRIUM_NS.hasTimeColumn, Literal(time_col)))
-        graph.add((parquet_ref, ACQUIRIUM_NS.hasValueColumn, Literal(value_col)))
+        graph.add((file_ref, RDF.type, FILE_REFERENCE))
+        graph.add((file_ref, DATA_SOURCE, Literal("Lab")))
+        graph.add((file_ref, FILE_LOCATION, Literal(file_path)))
+        graph.add((file_ref, TIME_COLUMN_ID, Literal(time_col)))
+        graph.add((file_ref, VALUE_COLUMN_ID, Literal(value_col)))
 
-        graph.add((mqtt_ref, RDF.type, ACQUIRIUM_NS.MQTTReference))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.Broker, Literal(broker)))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.Port, Literal(port)))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.Topic, Literal(f"{topic_prefix}/{name}")))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.time_key, Literal("Timestamp")))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.value_key, Literal("Value")))
+        graph.add((mqtt_ref, RDF.type, MQTT_REFERENCE))
+        graph.add((mqtt_ref, DATA_SOURCE, Literal("SCADA")))
+        graph.add((mqtt_ref, MQTT_BROKER, Literal(broker_literal)))
+        graph.add((mqtt_ref, MQTT_TOPIC, Literal(f"{topic_prefix}/{name}")))
+        graph.add((mqtt_ref, TIME_KEY, Literal("Timestamp")))
+        graph.add((mqtt_ref, VALUE_KEY, Literal("Value")))
 
 
 def add_thresholds(graph: rdflib.Graph) -> None:
@@ -434,15 +451,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--time-column",
-        type=int,
-        default=0,
-        help="Time column index for parquet references.",
+        default="0",
+        help="Time column name (or numeric index as a string) for ref:FileReference.",
     )
     parser.add_argument(
         "--value-column",
-        type=int,
-        default=1,
-        help="Value column index for parquet references.",
+        default="1",
+        help="Value column name (or numeric index as a string) for ref:FileReference.",
     )
     args = parser.parse_args()
 
@@ -462,6 +477,7 @@ def main() -> None:
     add_thresholds(graph)
 
     graph.bind("acq", ACQUIRIUM_NS)
+    graph.bind("ref", BRICK_REF)
     graph.bind("unit", QUDT_UNIT)
     graph.bind("s223", S223)
     graph.bind("xsd", XSD)

--- a/deployments/BENICIA/scripts/add_external_refs_bench.py
+++ b/deployments/BENICIA/scripts/add_external_refs_bench.py
@@ -5,7 +5,19 @@ import rdflib
 from rdflib import Literal
 from rdflib.namespace import RDF, XSD
 
-from acquirium.internals.internals_namespaces import ACQUIRIUM_NS, QUDT_UNIT, S223
+from acquirium.internals.internals_namespaces import (
+    ACQUIRIUM_NS,
+    BRICK_REF,
+    DATA_SOURCE,
+    HAS_EXTERNAL_REFERENCE,
+    MQTT_BROKER,
+    MQTT_REFERENCE,
+    MQTT_TOPIC,
+    QUDT_UNIT,
+    S223,
+    TIME_KEY,
+    VALUE_KEY,
+)
 
 
 PROPERTY_TYPES = {
@@ -54,6 +66,7 @@ def add_external_references(
     count_refs: int,
 ) -> None:
     wbs = rdflib.Namespace("urn:ex/")
+    broker_literal = f"{broker}:{port}" if port else broker
 
     i = 0
     for prop in properties:
@@ -63,14 +76,14 @@ def add_external_references(
         name = local_name(prop)
         mqtt_ref = wbs[f"{name}_mqtt_ref"]
 
-        graph.add((prop, ACQUIRIUM_NS.hasExternalReference, mqtt_ref))
+        graph.add((prop, HAS_EXTERNAL_REFERENCE, mqtt_ref))
 
-        graph.add((mqtt_ref, RDF.type, ACQUIRIUM_NS.MQTTReference))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.Broker, Literal(broker)))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.Port, Literal(port)))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.Topic, Literal(f"{topic_prefix}/{name}")))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.time_key, Literal("Timestamp")))
-        graph.add((mqtt_ref, ACQUIRIUM_NS.value_key, Literal("Value")))
+        graph.add((mqtt_ref, RDF.type, MQTT_REFERENCE))
+        graph.add((mqtt_ref, DATA_SOURCE, Literal("SCADA")))
+        graph.add((mqtt_ref, MQTT_BROKER, Literal(broker_literal)))
+        graph.add((mqtt_ref, MQTT_TOPIC, Literal(f"{topic_prefix}/{name}")))
+        graph.add((mqtt_ref, TIME_KEY, Literal("Timestamp")))
+        graph.add((mqtt_ref, VALUE_KEY, Literal("Value")))
 
 
 
@@ -117,6 +130,7 @@ def main() -> None:
     )
 
     graph.bind("acq", ACQUIRIUM_NS)
+    graph.bind("ref", BRICK_REF)
     graph.bind("unit", QUDT_UNIT)
     graph.bind("s223", S223)
     graph.bind("xsd", XSD)

--- a/deployments/WATERTAP/models/watertap-simple-pipe-model-with-ext-refs.ttl
+++ b/deployments/WATERTAP/models/watertap-simple-pipe-model-with-ext-refs.ttl
@@ -1,5 +1,6 @@
 @prefix nawi: <urn:nawi-water-ontology#> .
 @prefix ns1: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix qudtqk: <http://qudt.org/vocab/quantitykind/> .
@@ -27,61 +28,56 @@ wbs:Pump1-in-flow-mass-seawater a s223:QuantifiableObservableProperty ;
     s223:ofMedium nawi:Water-Seawater ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference wbs:pump_inlet_flow_mass_seawater_mqtt_ref .
+    ref:hasExternalReference wbs:pump_inlet_flow_mass_seawater_mqtt_ref .
 
 wbs:Pump1-in-flow-mass-water a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference wbs:pump_inlet_flow_mass_water_mqtt_ref .
+    ref:hasExternalReference wbs:pump_inlet_flow_mass_water_mqtt_ref .
 
 wbs:Pump1-in-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    ns1:hasExternalReference wbs:pump_inlet_pressure_mqtt_ref .
+    ref:hasExternalReference wbs:pump_inlet_pressure_mqtt_ref .
 
 wbs:Pump1-in-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    ns1:hasExternalReference wbs:pump_inlet_temperature_mqtt_ref .
+    ref:hasExternalReference wbs:pump_inlet_temperature_mqtt_ref .
 
 wbs:Pump1-out a s223:OutletConnectionPoint ;
     s223:hasMedium s223:Medium-Water .
 
 wbs:PumpWork a s223:QuantifiableObservableProperty ;
     rdfs:comment "SOFT SENSOR" ;
-    ns1:hasExternalReference wbs:pump_work_mqtt_ref .
+    ref:hasExternalReference wbs:pump_work_mqtt_ref .
 
-wbs:pump_inlet_flow_mass_seawater_mqtt_ref a ns1:MQTTReference ;
-    ns1:Broker "mosquitto" ;
-    ns1:Port "1883" ;
-    ns1:Topic "saltwater_flow_mass_rate" ;
-    ns1:time_key "Timestamp" ;
-    ns1:value_key "Value" .
+wbs:pump_inlet_flow_mass_seawater_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "saltwater_flow_mass_rate" ;
+    ns1:timeKey "Timestamp" ;
+    ns1:valueKey "Value" .
 
-wbs:pump_inlet_flow_mass_water_mqtt_ref a ns1:MQTTReference ;
-    ns1:Broker "mosquitto" ;
-    ns1:Port "1883" ;
-    ns1:Topic "water_flow_mass_rate" ;
-    ns1:time_key "Timestamp" ;
-    ns1:value_key "Value" .
+wbs:pump_inlet_flow_mass_water_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "water_flow_mass_rate" ;
+    ns1:timeKey "Timestamp" ;
+    ns1:valueKey "Value" .
 
-wbs:pump_inlet_pressure_mqtt_ref a ns1:MQTTReference ;
-    ns1:Broker "mosquitto" ;
-    ns1:Port "1883" ;
-    ns1:Topic "pump_inlet_pressure" ;
-    ns1:time_key "Timestamp" ;
-    ns1:value_key "Value" .
+wbs:pump_inlet_pressure_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "pump_inlet_pressure" ;
+    ns1:timeKey "Timestamp" ;
+    ns1:valueKey "Value" .
 
-wbs:pump_inlet_temperature_mqtt_ref a ns1:MQTTReference ;
-    ns1:Broker "mosquitto" ;
-    ns1:Port "1883" ;
-    ns1:Topic "pump_inlet_temperature" ;
-    ns1:time_key "Timestamp" ;
-    ns1:value_key "Value" .
+wbs:pump_inlet_temperature_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "pump_inlet_temperature" ;
+    ns1:timeKey "Timestamp" ;
+    ns1:valueKey "Value" .
 
-wbs:pump_work_mqtt_ref a ns1:MQTTReference ;
-    ns1:Broker "mosquitto" ;
-    ns1:Port "1883" ;
-    ns1:Topic "pump_work" ;
-    ns1:time_key "Timestamp" ;
-    ns1:value_key "Value" .
+wbs:pump_work_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "pump_work" ;
+    ns1:timeKey "Timestamp" ;
+    ns1:valueKey "Value" .
 

--- a/deployments/WATERTAP/scripts/insert_external_ref.py
+++ b/deployments/WATERTAP/scripts/insert_external_ref.py
@@ -1,61 +1,44 @@
 import rdflib
-from acquirium.internals.internals_namespaces import *
+from acquirium.internals.internals_namespaces import (
+    ACQUIRIUM_NS,
+    BRICK_REF,
+    DATA_SOURCE,
+    HAS_EXTERNAL_REFERENCE,
+    MQTT_BROKER,
+    MQTT_REFERENCE,
+    MQTT_TOPIC,
+    S223,
+    TIME_KEY,
+    VALUE_KEY,
+)
 
 wbs = rdflib.Namespace("urn:ex/")
 watr = rdflib.Namespace("urn:nawi-water-ontology#")
 s223 = rdflib.Namespace("http://data.ashrae.org/standard223#")
-ref_ns = ACQUIRIUM_NS
 
 model = rdflib.Graph().parse("deployments/WATERTAP/models/watertap-simple-pipe-model.ttl", format="turtle")
+model.bind("acq", ACQUIRIUM_NS)
+model.bind("ref", BRICK_REF)
 
 model.add((wbs.Pump1, s223.hasProperty, wbs.PumpWork))
-model.add((wbs.PumpWork, rdflib.RDF.type, s223.QuantifiableObservableProperty ))
+model.add((wbs.PumpWork, rdflib.RDF.type, s223.QuantifiableObservableProperty))
 model.add((wbs.PumpWork, rdflib.RDFS.comment, rdflib.Literal("SOFT SENSOR")))
 
-blnk = wbs.pump_work_mqtt_ref
-model.add((wbs.PumpWork, ref_ns.hasExternalReference, blnk))
-model.add((blnk, rdflib.RDF.type, ref_ns.MQTTReference))
-model.add((blnk, ref_ns.Broker, rdflib.Literal("mosquitto")))
-model.add((blnk, ref_ns.Port, rdflib.Literal("1883")))
-model.add((blnk, ref_ns.Topic, rdflib.Literal("pump_work")))
-model.add((blnk, ref_ns.value_key, rdflib.Literal("Value")))
-model.add((blnk, ref_ns.time_key, rdflib.Literal("Timestamp")))
+
+def add_mqtt_ref(point: rdflib.URIRef, ref_node: rdflib.URIRef, topic: str) -> None:
+    model.add((point, HAS_EXTERNAL_REFERENCE, ref_node))
+    model.add((ref_node, rdflib.RDF.type, MQTT_REFERENCE))
+    model.add((ref_node, DATA_SOURCE, rdflib.Literal("SCADA")))
+    model.add((ref_node, MQTT_BROKER, rdflib.Literal("mosquitto:1883")))
+    model.add((ref_node, MQTT_TOPIC, rdflib.Literal(topic)))
+    model.add((ref_node, TIME_KEY, rdflib.Literal("Timestamp")))
+    model.add((ref_node, VALUE_KEY, rdflib.Literal("Value")))
 
 
-blnk = wbs.pump_inlet_flow_mass_seawater_mqtt_ref
-model.add((wbs['Pump1-in-flow-mass-seawater'], ref_ns.hasExternalReference, blnk))
-model.add((blnk, rdflib.RDF.type, ref_ns.MQTTReference))
-model.add((blnk, ref_ns.Broker, rdflib.Literal("mosquitto")))
-model.add((blnk, ref_ns.Port, rdflib.Literal("1883")))
-model.add((blnk, ref_ns.Topic, rdflib.Literal("saltwater_flow_mass_rate")))
-model.add((blnk, ref_ns.value_key, rdflib.Literal("Value")))
-model.add((blnk, ref_ns.time_key, rdflib.Literal("Timestamp")))
-
-blnk = wbs.pump_inlet_flow_mass_water_mqtt_ref
-model.add((wbs['Pump1-in-flow-mass-water'], ref_ns.hasExternalReference, blnk))
-model.add((blnk, rdflib.RDF.type, ref_ns.MQTTReference))
-model.add((blnk, ref_ns.Broker, rdflib.Literal("mosquitto")))
-model.add((blnk, ref_ns.Port, rdflib.Literal("1883")))
-model.add((blnk, ref_ns.Topic, rdflib.Literal("water_flow_mass_rate")))
-model.add((blnk, ref_ns.value_key, rdflib.Literal("Value")))
-model.add((blnk, ref_ns.time_key, rdflib.Literal("Timestamp")))
-
-blnk = wbs.pump_inlet_pressure_mqtt_ref
-model.add((wbs['Pump1-in-pressure'], ref_ns.hasExternalReference, blnk))
-model.add((blnk, rdflib.RDF.type, ref_ns.MQTTReference))
-model.add((blnk, ref_ns.Broker, rdflib.Literal("mosquitto")))
-model.add((blnk, ref_ns.Port, rdflib.Literal("1883")))
-model.add((blnk, ref_ns.Topic, rdflib.Literal("pump_inlet_pressure")))
-model.add((blnk, ref_ns.value_key, rdflib.Literal("Value")))
-model.add((blnk, ref_ns.time_key, rdflib.Literal("Timestamp")))
-
-blnk = wbs.pump_inlet_temperature_mqtt_ref
-model.add((wbs['Pump1-in-temperature'], ref_ns.hasExternalReference, blnk))
-model.add((blnk, rdflib.RDF.type, ref_ns.MQTTReference))
-model.add((blnk, ref_ns.Broker, rdflib.Literal("mosquitto")))
-model.add((blnk, ref_ns.Port, rdflib.Literal("1883")))
-model.add((blnk, ref_ns.Topic, rdflib.Literal("pump_inlet_temperature")))
-model.add((blnk, ref_ns.value_key, rdflib.Literal("Value")))
-model.add((blnk, ref_ns.time_key, rdflib.Literal("Timestamp")))
+add_mqtt_ref(wbs.PumpWork, wbs.pump_work_mqtt_ref, "pump_work")
+add_mqtt_ref(wbs["Pump1-in-flow-mass-seawater"], wbs.pump_inlet_flow_mass_seawater_mqtt_ref, "saltwater_flow_mass_rate")
+add_mqtt_ref(wbs["Pump1-in-flow-mass-water"], wbs.pump_inlet_flow_mass_water_mqtt_ref, "water_flow_mass_rate")
+add_mqtt_ref(wbs["Pump1-in-pressure"], wbs.pump_inlet_pressure_mqtt_ref, "pump_inlet_pressure")
+add_mqtt_ref(wbs["Pump1-in-temperature"], wbs.pump_inlet_temperature_mqtt_ref, "pump_inlet_temperature")
 
 model.serialize("deployments/WATERTAP/models/watertap-simple-pipe-model-with-ext-refs.ttl", format="turtle")

--- a/deployments/WATERTAP2/models/test-model.ttl
+++ b/deployments/WATERTAP2/models/test-model.ttl
@@ -1,5 +1,6 @@
 @prefix nawi: <urn:nawi-water-ontology#> .
 @prefix ns1: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix qudtqk: <http://qudt.org/vocab/quantitykind/> .
@@ -34,19 +35,19 @@ wbs:P1-in a s223:InletConnectionPoint ;
 
 wbs:P1-in-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    ns1:hasExternalReference ns1:P1-in-pressure_watertap_ref ;
+    ref:hasExternalReference ns1:P1-in-pressure_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_in[0.0].pressure" .
 
 wbs:P1-in-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    ns1:hasExternalReference ns1:P1-in-temperature_watertap_ref ;
+    ref:hasExternalReference ns1:P1-in-temperature_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_in[0.0].temperature" .
 
 wbs:P1-in-watertap-mass-flow a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P1-in-watertap-mass-flow_watertap_ref ;
+    ref:hasExternalReference ns1:P1-in-watertap-mass-flow_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_in[0.0].flow_mass_phase_comp[Liq,H2O]" .
 
 wbs:P1-in-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
@@ -54,53 +55,53 @@ wbs:P1-in-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Salt-NaCl ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P1-in-watertap-mass-flow-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P1-in-watertap-mass-flow-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_in[0.0].flow_mass_phase_comp[Liq,NaCl]" .
 
 wbs:P1-in-watertap-mass-frac-h2o a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
-    ns1:hasExternalReference ns1:P1-in-watertap-mass-frac-h2o_watertap_ref ;
+    ref:hasExternalReference ns1:P1-in-watertap-mass-frac-h2o_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_in[0.0].mass_frac_phase_comp[Liq,H2O]" .
 
 wbs:P1-in-watertap-mass-frac-nacl a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Salt-NaCl ;
-    ns1:hasExternalReference ns1:P1-in-watertap-mass-frac-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P1-in-watertap-mass-frac-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_in[0.0].mass_frac_phase_comp[Liq,NaCl]" .
 
 wbs:P1-in-watertap-specific-enthalpy a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:SpecificEnthalpy ;
     qudt:hasUnit unit:J-PER-KiloGM ;
-    ns1:hasExternalReference ns1:P1-in-watertap-specific-enthalpy_watertap_ref ;
+    ref:hasExternalReference ns1:P1-in-watertap-specific-enthalpy_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_in[0.0].enth_mass_phase[Liq]" .
 
 wbs:P1-out-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    ns1:hasExternalReference ns1:P1-out-pressure_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-pressure_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].pressure" .
 
 wbs:P1-out-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    ns1:hasExternalReference ns1:P1-out-temperature_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-temperature_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].temperature" .
 
 wbs:P1-out-watertap-density-phase a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:KiloGM-PER-M3 ;
-    ns1:hasExternalReference ns1:P1-out-watertap-density-phase_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-watertap-density-phase_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].dens_mass_phase[Liq]" .
 
 wbs:P1-out-watertap-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
     qudt:hasUnit unit:M3-PER-SEC ;
-    ns1:hasExternalReference ns1:P1-out-watertap-flow-rate_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-watertap-flow-rate_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].flow_vol_phase[Liq]" .
 
 wbs:P1-out-watertap-mass-flow a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P1-out-watertap-mass-flow_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-watertap-mass-flow_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].flow_mass_phase_comp[Liq,H2O]" .
 
 wbs:P1-out-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
@@ -108,68 +109,68 @@ wbs:P1-out-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Salt-NaCl ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P1-out-watertap-mass-flow-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-watertap-mass-flow-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].flow_mass_phase_comp[Liq,NaCl]" .
 
 wbs:P1-out-watertap-mass-frac-h2o a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
-    ns1:hasExternalReference ns1:P1-out-watertap-mass-frac-h2o_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-watertap-mass-frac-h2o_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].mass_frac_phase_comp[Liq,H2O]" .
 
 wbs:P1-out-watertap-mass-frac-nacl a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Salt-NaCl ;
-    ns1:hasExternalReference ns1:P1-out-watertap-mass-frac-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-watertap-mass-frac-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].mass_frac_phase_comp[Liq,NaCl]" .
 
 wbs:P1-out-watertap-specific-enthalpy a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:SpecificEnthalpy ;
     qudt:hasUnit unit:J-PER-KiloGM ;
-    ns1:hasExternalReference ns1:P1-out-watertap-specific-enthalpy_watertap_ref ;
+    ref:hasExternalReference ns1:P1-out-watertap-specific-enthalpy_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.properties_out[0.0].enth_mass_phase[Liq]" .
 
 wbs:P1-watertap-delta-P a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
     qudt:hasUnit unit:PSI ;
-    ns1:hasExternalReference ns1:P1-watertap-delta-P_watertap_ref ;
+    ref:hasExternalReference ns1:P1-watertap-delta-P_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.deltaP[0.0]" .
 
 wbs:P1-watertap-efficiency a s223:QuantifiableObservableProperty ;
-    ns1:hasExternalReference ns1:P1-watertap-efficiency_watertap_ref ;
+    ref:hasExternalReference ns1:P1-watertap-efficiency_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.efficiency_pump[0.0]" .
 
 wbs:P1-watertap-ratio a s223:QuantifiableObservableProperty ;
-    ns1:hasExternalReference ns1:P1-watertap-ratio_watertap_ref ;
+    ref:hasExternalReference ns1:P1-watertap-ratio_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.ratioP[0.0]" .
 
 wbs:P1-watertap-work a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Power ;
     qudt:hasUnit unit:W ;
-    ns1:hasExternalReference ns1:P1-watertap-work_watertap_ref ;
+    ref:hasExternalReference ns1:P1-watertap-work_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.control_volume.work[0.0]" .
 
 wbs:P1-watertap-work-fluid a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Mix-Fluid ;
     qudt:hasQuantityKind qudtqk:Power ;
     qudt:hasUnit unit:W ;
-    ns1:hasExternalReference ns1:P1-watertap-work-fluid_watertap_ref ;
+    ref:hasExternalReference ns1:P1-watertap-work-fluid_watertap_ref ;
     ns1:hasPyomoVar "fs.P1.work_fluid[0.0]" .
 
 wbs:P2-in-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    ns1:hasExternalReference ns1:P2-in-pressure_watertap_ref ;
+    ref:hasExternalReference ns1:P2-in-pressure_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_in[0.0].pressure" .
 
 wbs:P2-in-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    ns1:hasExternalReference ns1:P2-in-temperature_watertap_ref ;
+    ref:hasExternalReference ns1:P2-in-temperature_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_in[0.0].temperature" .
 
 wbs:P2-in-watertap-mass-flow a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P2-in-watertap-mass-flow_watertap_ref ;
+    ref:hasExternalReference ns1:P2-in-watertap-mass-flow_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_in[0.0].flow_mass_phase_comp[Liq,H2O]" .
 
 wbs:P2-in-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
@@ -177,24 +178,24 @@ wbs:P2-in-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Salt-NaCl ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P2-in-watertap-mass-flow-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P2-in-watertap-mass-flow-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_in[0.0].flow_mass_phase_comp[Liq,NaCl]" .
 
 wbs:P2-in-watertap-mass-frac-h2o a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
-    ns1:hasExternalReference ns1:P2-in-watertap-mass-frac-h2o_watertap_ref ;
+    ref:hasExternalReference ns1:P2-in-watertap-mass-frac-h2o_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_in[0.0].mass_frac_phase_comp[Liq,H2O]" .
 
 wbs:P2-in-watertap-mass-frac-nacl a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Salt-NaCl ;
-    ns1:hasExternalReference ns1:P2-in-watertap-mass-frac-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P2-in-watertap-mass-frac-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_in[0.0].mass_frac_phase_comp[Liq,NaCl]" .
 
 wbs:P2-in-watertap-specific-enthalpy a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:SpecificEnthalpy ;
     qudt:hasUnit unit:J-PER-KiloGM ;
-    ns1:hasExternalReference ns1:P2-in-watertap-specific-enthalpy_watertap_ref ;
+    ref:hasExternalReference ns1:P2-in-watertap-specific-enthalpy_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_in[0.0].enth_mass_phase[Liq]" .
 
 wbs:P2-out a s223:OutletConnectionPoint ;
@@ -211,31 +212,31 @@ wbs:P2-out a s223:OutletConnectionPoint ;
 
 wbs:P2-out-pressure a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
-    ns1:hasExternalReference ns1:P2-out-pressure_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-pressure_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].pressure" .
 
 wbs:P2-out-temperature a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Temperature ;
-    ns1:hasExternalReference ns1:P2-out-temperature_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-temperature_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].temperature" .
 
 wbs:P2-out-watertap-density-phase a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Density ;
     qudt:hasUnit unit:KiloGM-PER-M3 ;
-    ns1:hasExternalReference ns1:P2-out-watertap-density-phase_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-watertap-density-phase_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].dens_mass_phase[Liq]" .
 
 wbs:P2-out-watertap-flow-rate a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
     qudt:hasUnit unit:M3-PER-SEC ;
-    ns1:hasExternalReference ns1:P2-out-watertap-flow-rate_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-watertap-flow-rate_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].flow_vol_phase[Liq]" .
 
 wbs:P2-out-watertap-mass-flow a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P2-out-watertap-mass-flow_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-watertap-mass-flow_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].flow_mass_phase_comp[Liq,H2O]" .
 
 wbs:P2-out-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
@@ -243,81 +244,81 @@ wbs:P2-out-watertap-mass-flow-nacl a s223:QuantifiableObservableProperty ;
     s223:ofSubstance nawi:Salt-NaCl ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference ns1:P2-out-watertap-mass-flow-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-watertap-mass-flow-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].flow_mass_phase_comp[Liq,NaCl]" .
 
 wbs:P2-out-watertap-mass-frac-h2o a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
-    ns1:hasExternalReference ns1:P2-out-watertap-mass-frac-h2o_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-watertap-mass-frac-h2o_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].mass_frac_phase_comp[Liq,H2O]" .
 
 wbs:P2-out-watertap-mass-frac-nacl a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance nawi:Salt-NaCl ;
-    ns1:hasExternalReference ns1:P2-out-watertap-mass-frac-nacl_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-watertap-mass-frac-nacl_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].mass_frac_phase_comp[Liq,NaCl]" .
 
 wbs:P2-out-watertap-specific-enthalpy a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:SpecificEnthalpy ;
     qudt:hasUnit unit:J-PER-KiloGM ;
-    ns1:hasExternalReference ns1:P2-out-watertap-specific-enthalpy_watertap_ref ;
+    ref:hasExternalReference ns1:P2-out-watertap-specific-enthalpy_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.properties_out[0.0].enth_mass_phase[Liq]" .
 
 wbs:P2-watertap-delta-P a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Pressure ;
     qudt:hasUnit unit:PSI ;
-    ns1:hasExternalReference ns1:P2-watertap-delta-P_watertap_ref ;
+    ref:hasExternalReference ns1:P2-watertap-delta-P_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.deltaP[0.0]" .
 
 wbs:P2-watertap-efficiency a s223:QuantifiableObservableProperty ;
-    ns1:hasExternalReference ns1:P2-watertap-efficiency_watertap_ref ;
+    ref:hasExternalReference ns1:P2-watertap-efficiency_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.efficiency_pump[0.0]" .
 
 wbs:P2-watertap-ratio a s223:QuantifiableObservableProperty ;
-    ns1:hasExternalReference ns1:P2-watertap-ratio_watertap_ref ;
+    ref:hasExternalReference ns1:P2-watertap-ratio_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.ratioP[0.0]" .
 
 wbs:P2-watertap-work a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Power ;
     qudt:hasUnit unit:W ;
-    ns1:hasExternalReference ns1:P2-watertap-work_watertap_ref ;
+    ref:hasExternalReference ns1:P2-watertap-work_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.control_volume.work[0.0]" .
 
 wbs:P2-watertap-work-fluid a s223:QuantifiableObservableProperty ;
     s223:ofMedium s223:Mix-Fluid ;
     qudt:hasQuantityKind qudtqk:Power ;
     qudt:hasUnit unit:W ;
-    ns1:hasExternalReference ns1:P2-watertap-work-fluid_watertap_ref ;
+    ref:hasExternalReference ns1:P2-watertap-work-fluid_watertap_ref ;
     ns1:hasPyomoVar "fs.P2.work_fluid[0.0]" .
 
 wbs:RO-watertap-area a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Area ;
     qudt:hasUnit unit:M2 ;
-    ns1:hasExternalReference ns1:RO-watertap-area_watertap_ref ;
+    ref:hasExternalReference ns1:RO-watertap-area_watertap_ref ;
     ns1:hasPyomoVar "fs.RO.area" .
 
 wbs:RO-watertap-height a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Length ;
     qudt:hasUnit unit:M ;
-    ns1:hasExternalReference ns1:RO-watertap-height_watertap_ref ;
+    ref:hasExternalReference ns1:RO-watertap-height_watertap_ref ;
     ns1:hasPyomoVar "fs.RO.feed_side.channel_height" .
 
 wbs:RO-watertap-permeability-coef-solute a s223:QuantifiableObservableProperty ;
-    ns1:hasExternalReference ns1:RO-watertap-permeability-coef-solute_watertap_ref ;
+    ref:hasExternalReference ns1:RO-watertap-permeability-coef-solute_watertap_ref ;
     ns1:hasPyomoVar "fs.RO.B_comp[0.0,NaCl]" .
 
 wbs:RO-watertap-permeability-coef-solvent a s223:QuantifiableObservableProperty ;
-    ns1:hasExternalReference ns1:RO-watertap-permeability-coef-solvent_watertap_ref ;
+    ref:hasExternalReference ns1:RO-watertap-permeability-coef-solvent_watertap_ref ;
     ns1:hasPyomoVar "fs.RO.A_comp[0.0,H2O]" .
 
 wbs:RO-watertap-spacer-porosity a s223:QuantifiableObservableProperty ;
-    ns1:hasExternalReference ns1:RO-watertap-spacer-porosity_watertap_ref ;
+    ref:hasExternalReference ns1:RO-watertap-spacer-porosity_watertap_ref ;
     ns1:hasPyomoVar "fs.RO.feed_side.spacer_porosity" .
 
 wbs:RO-watertap-width a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Length ;
     qudt:hasUnit unit:M ;
-    ns1:hasExternalReference ns1:RO-watertap-width_watertap_ref ;
+    ref:hasExternalReference ns1:RO-watertap-width_watertap_ref ;
     ns1:hasPyomoVar "fs.RO.width" .
 
 wbs:P1-out a s223:OutletConnectionPoint ;

--- a/deployments/WATERTAP2/scripts/input_gui.py
+++ b/deployments/WATERTAP2/scripts/input_gui.py
@@ -65,21 +65,22 @@ def _iso_now() -> str:
 def load_mappings_from_ttl(ttl_path: str) -> Dict[str, str]:
     """
     Reads TTL and extracts { pyomo_var_name -> point_uri } using:
-      ?s acquirium:hasExternalReference ?point_uri .
-      ?s acquirium:hasPyomoVar ?pyomo_var .
+      ?s ref:hasExternalReference ?point_uri .
+      ?s acquirium:hasPyomoVar  ?pyomo_var .
     """
     g = rdflib.Graph().parse(ttl_path, format="turtle")
     acq = rdflib.Namespace("urn:acquirium#")
+    ref = rdflib.Namespace("https://brickschema.org/schema/Brick/ref#")
 
     mappings: Dict[str, str] = {}
-    for s, _, point_uri in g.triples((None, acq.hasExternalReference, None)):
+    for s, _, point_uri in g.triples((None, ref.hasExternalReference, None)):
         for _, _, pyomo_var in g.triples((s, acq.hasPyomoVar, None)):
             mappings[str(pyomo_var)] = str(point_uri)
 
     if not mappings:
         raise ValueError(
             "No mappings found in TTL. Expected triples using "
-            "urn:acquirium#hasExternalReference and urn:acquirium#hasPyomoVar."
+            "ref:hasExternalReference and urn:acquirium#hasPyomoVar."
         )
 
     return mappings

--- a/deployments/WATERTAP2/scripts/push_watertap_points.py
+++ b/deployments/WATERTAP2/scripts/push_watertap_points.py
@@ -117,7 +117,8 @@ def main() -> None:
     G = rdflib.Graph().parse("deployments/WATERTAP2/models/test-model.ttl", format="turtle")
     mappings = {}
     ACQUIRIUM_NS = rdflib.Namespace("urn:acquirium#")
-    for s,p,o in G.triples((None, ACQUIRIUM_NS.hasExternalReference, None)):
+    REF_NS = rdflib.Namespace("https://brickschema.org/schema/Brick/ref#")
+    for s,p,o in G.triples((None, REF_NS.hasExternalReference, None)):
         for s2,p2,o2 in G.triples((s, ACQUIRIUM_NS.hasPyomoVar, None)):
             mappings[str(o2)] = str(o)
     

--- a/deployments/readme.md
+++ b/deployments/readme.md
@@ -62,12 +62,14 @@ This is especially useful when moving between simulated data and real deployment
 
 Each external reference node should correspond to a single access pattern.
 
+The external reference schema is borrowed from [Brick Ref]().
+
 Existing external reference types (open an issue or contact us for other!):
 
-- "urn:acquirium#CSVReference"      : for connecting CSV files
-- "urn:acquirium#ParquetReference"  : for connecting Parquet files
-- "urn:acquirium#MQTTReference"     : for connecting MQTT streams
-- "urn:acquirium#PGReference"       : for connection a Postgres database
+- "https://brickschema.org/schema/Brick/ref#FileReference"          : for connecting Parquet or CSV files
+- "https://brickschema.org/schema/Brick/ref#MQTTReference"          : for connecting MQTT streams
+- "https://brickschema.org/schema/Brick/ref#TimeseriesReference"    : for connection a database server
+
 
 ---
 ### 5. Reference Specific Triples
@@ -78,90 +80,75 @@ This section describes the minimum triples required for each external reference 
 
 `acq = urn:acquirium#`
 
+`ref = https://brickschema.org/schema/Brick/ref#`
+
 Every external reference assignment should include:
 
 - A link from the data node to the reference node  
-  `data_node acq:hasExternalReference ref_node`
+  `data_node ref:hasExternalReference ref_node`
+  `data_node ref:hasFileReference ref_node`
+  `data_node ref:hasMQTTReference ref_node`
+  `data_node ref:hasTimeseriesReference ref_node`
 
 - A type assertion for the reference node (pick the data format)
-  `ref_node a acq:CSVReference`  
-  `ref_node a acq:MQTTReference`  
-  `ref_node a acq:ParquetReference`
+  `ref_node a ref:FileReference`
+  `ref_node a ref:MQTTReference`  
+  `ref_node a ref:TimeseriesReference`  
 
 ---
 
-#### 5.2 CSVReference
+#### 5.2 FileReference
 
-Use a CSV reference when data is stored in a local or mounted CSV file.
+Use a File reference when data is stored in a local or mounted CSV or Parquet file. Acquirium will infer the type of the file.
 
-Required triples for `acq:CSVReference`:
+Required triples for `ref:FileReference`:
 
-- `ref_node a acq:CSVReference`
-- `ref_node acq:DataSource "..."`           Path in string format as rdflib.Literal
-- `ref_node acq:hasFilePath "..."`          Path in string format as rdflib.Literal
-- `ref_node acq:hasTimeColumn <integer>`
-- `ref_node acq:hasValueColumn <integer>`
-
----
-
-#### 5.2 ParquetReference
-
-Use a Parquet reference when data is stored in a local or mounted Parquet file.
-
-Required triples for `acq:ParquetReference`:
-
-- `ref_node a acq:ParquetReference`
-- `ref_node acq:DataSource "..."`           Path in string format as rdflib.Literal
-- `ref_node acq:hasFilePath "..."`          Path in string format as rdflib.Literal
-- `ref_node acq:hasTimeColumn <integer>`
-- `ref_node acq:hasValueColumn <integer>`
+- `ref_node a ref:FileReference`
+- `ref_node acq:DataSource "..."`            In string format as rdflib.Literal (e.g. "Lab", "SCADA", ...)
+- `ref_node ref:fileLocation "..."`          Path in string format as rdflib.Literal
+- `ref_node ref:timeColumnID "..."`          Time column name or id (optional, Acquirium infers time column automatically, however if there's ambiguity it will raise an error)
+- `ref_node ref:valueColumnID "..."`         Value column name or id (required)
 
 ---
 
 #### 5.4 MQTTReference
 
-Use an MQTT reference for live or replayed streaming data.
+Use an MQTT reference for live or replayed streaming data. (right now we assume all payload is a dictionary, this will be changed to Sparkplug Schema)
 
-Required triples for `acq:MQTTReference`:
+Required triples for `ref:MQTTReference`:
 
-- `ref_node a acq:MQTTReference`
-- `ref_node acq:Broker "..."`           (e.g. `localhost`)
-- `ref_node acq:Port <integer>`      
-- `ref_node acq:Topic "..."`
-- `ref_node acq:time_key "Timestamp"`
-- `ref_node acq:value_key "Value"`
+- `ref_node a ref:MQTTReference`
+- `ref_node ref:MQTTBroker "..."`         Required. Accepts `host`, `host:port`, or a `mqtt(s)://...` URI (e.g. `localhost:1883`). Defaults to port 1883 when no port is given.
+- `ref_node ref:MQTTTopic "..."`          Required
+- `ref_node acq:timeKey "Timestamp"`      Acquirium-specific: name of the JSON key carrying the timestamp.
+- `ref_node acq:valueKey "Value"`         Acquirium-specific: name of the JSON key carrying the value.
 
 **Important Note:** We currently assume that the incoming message is in json format. If your MQTT stream sends data in other format, please open an issue or contact us!
 
 ---
 
-#### 5.5 PGReference
+#### 5.5 TimeseriesReference
 
-Use an existing Postgres Database to retrieve data (e.g. a historian)
+Use an existing Postgres database to retrieve data (e.g. a historian).
 
-Required triples for `acq:PGReference`:
+Required triples for `ref:TimeseriesReference`:
 
-- `ref_node a acq:PGReference`
-
-
-CHOOSE EITHER:
-- `ref_node acq:PG_DSN "postgresql://user:pass@localhost:5432/dpr" `
-OR
-- `ref_node acq:PG_HOST "localhost"`
-- `ref_node acq:PG_PORT "5432"`           (default: `5432`)
-- `ref_node acq:PG_DB "dpr"`
-- `ref_node acq:PG_USER "user"`
-- `ref_node acq:PG_PASS "pass"`
+- `ref_node a ref:TimeseriesReference`
+- `ref_node ref:storedAt "postgresql://user:pass@localhost:5432/dpr"`   The DSN as a literal string. Acquirium recognises `postgresql://` and `postgres://` literals as external Postgres references.
 
 THEN CHOOSE EITHER:
-- `ref_node acq:PG_Query "SELECT time, value FROM data WHERE point_uri = 'sensor1' ORDER BY time"`
-OR
-- `ref_node acq:PG_Table "data"`
-- `ref_node acq:PG_TimeColumn "time"`     (default: `time`)
-- `ref_node acq:PG_ValueColumn "value"`   (default: `value`)
-- `ref_node acq:PG_PointFilter "sensor1"` (optional — filters by `point_uri` column in the external table)
+- `ref_node acq:timeseriesQuery "SELECT time, value FROM data WHERE point_uri = 'sensor1' ORDER BY time"`
 
-**Important Note:** When using `PG_Query`, the query must return exactly two columns: the first for timestamps and the second for values. When using `PG_Table`, the table is expected to have a `point_uri` column if `PG_PointFilter` is provided.
+OR:
+- `ref_node acq:timeseriesTable "data"`
+- `ref_node acq:timeseriesTimeColumn "time"`     (default: `time`)
+- `ref_node acq:timeseriesValueColumn "value"`   (default: `value`)
+- `ref_node acq:timeseriesPointFilter "point_uri"` (optional — filters by `point_uri` column in the external table)
+
+**Important Note:**
+- The `acq:timeseries*` predicates are Acquirium-specific (not part of the Brick `ref:` schema), since they describe how Acquirium reads the external table.
+- When using `acq:timeseriesQuery`, the query must return exactly two columns: the first for timestamps and the second for values.
+- When using `acq:timeseriesTable`, the table is expected to have a `point_uri` column if `acq:timeseriesPointFilter` is provided.
 
 ---
 
@@ -170,56 +157,58 @@ OR
 The following example illustrates the full pattern using a pump work stream. It links a data node to an MQTT reference node and describes how to extract the timestamp and value from JSON payload fields.
 
 ```
-@PREFIX ns1: <urn:acquirium#>
-@PREFIX wbs: <urn:ex/> 
+@prefix acq: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix wbs: <urn:ex/> .
+
 wbs:Pump1-in-flow-mass-seawater a s223:QuantifiableObservableProperty ;
     s223:ofMedium nawi:Water-Seawater ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference wbs:pump_inlet_flow_mass_seawater_mqtt_ref .
+    ref:hasExternalReference wbs:pump_inlet_flow_mass_seawater_mqtt_ref .
 
-wbs:pump_inlet_flow_mass_seawater_mqtt_ref a ns1:MQTTReference ;
-    ns1:Broker "localhost" ;
-    ns1:Port "1883" ;
-    ns1:Topic "saltwater_flow_mass_rate" ;
-    ns1:time_key "Timestamp" ;
-    ns1:value_key "Value" .
+wbs:pump_inlet_flow_mass_seawater_mqtt_ref a ref:MQTTReference ;
+    acq:dataSource "SCADA" ;
+    ref:MQTTBroker "localhost:1883" ;
+    ref:MQTTTopic "saltwater_flow_mass_rate" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 ```
 ---
 
-### 7. Example: Assigning a PGReference (External Postgres Historian)
+### 7. Example: Assigning an External Timeseries Reference (Postgres Historian)
 
-The following example links a data node to a PGReference using a full DSN connection string. The external database table `data` stores rows in `(point_uri, time, value)` format, and `PG_PointFilter` selects only the rows matching this sensor.
+The following example links a data node to a `ref:TimeseriesReference` whose `ref:storedAt` is a literal Postgres DSN — Acquirium uses the `postgresql://` prefix to recognise it as an external historian rather than an Acquirium-managed stream. The external table `data` stores rows in `(point_uri, time, value)` format, and `acq:timeseriesPointFilter` selects only the rows matching this sensor.
 
 ```
-@PREFIX ns1: <urn:acquirium#>
-@PREFIX wbs: <urn:ex/>
+@prefix acq: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix wbs: <urn:ex/> .
+
 wbs:Pump1-in-flow-mass-seawater a s223:QuantifiableObservableProperty ;
     s223:ofMedium nawi:Water-Seawater ;
     qudt:hasQuantityKind qudtqk:MassFlowRate ;
     qudt:hasUnit unit:KiloGM-PER-SEC ;
-    ns1:hasExternalReference wbs:pump_inlet_flow_mass_seawater_pg_ref .
+    ref:hasExternalReference wbs:pump_inlet_flow_mass_seawater_pg_ref .
 
-wbs:pump_inlet_flow_mass_seawater_pg_ref a ns1:PGReference ;
-    ns1:PG_DSN "postgresql://user:pass@localhost:5432/dpr" ;
-    ns1:PG_Table "data" ;
-    ns1:PG_TimeColumn "time" ;
-    ns1:PG_ValueColumn "value" ;
-    ns1:PG_PointFilter "saltwater_flow_mass_rate" .
+wbs:pump_inlet_flow_mass_seawater_pg_ref a ref:TimeseriesReference ;
+    ref:storedAt "postgresql://user:pass@localhost:5432/dpr" ;
+    acq:timeseriesTable "data" ;
+    acq:timeseriesTimeColumn "time" ;
+    acq:timeseriesValueColumn "value" ;
+    acq:timeseriesPointFilter "saltwater_flow_mass_rate" .
 ```
 
-Alternatively, using individual connection parameters and a custom query:
+Alternatively, supply a full SQL query (which must return exactly two columns: timestamp first, then value):
 
 ```
-@PREFIX ns1: <urn:acquirium#>
-@PREFIX wbs: <urn:ex/>
-wbs:pump_inlet_flow_mass_seawater_pg_ref a ns1:PGReference ;
-    ns1:PG_HOST "localhost" ;
-    ns1:PG_PORT "5432" ;
-    ns1:PG_DB "dpr" ;
-    ns1:PG_USER "user" ;
-    ns1:PG_PASS "pass" ;
-    ns1:PG_Query "SELECT time, value FROM data WHERE point_uri = 'saltwater_flow_mass_rate' ORDER BY time" .
+@prefix acq: <urn:acquirium#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix wbs: <urn:ex/> .
+
+wbs:pump_inlet_flow_mass_seawater_pg_ref a ref:TimeseriesReference ;
+    ref:storedAt "postgresql://user:pass@localhost:5432/dpr" ;
+    acq:timeseriesQuery "SELECT time, value FROM data WHERE point_uri = 'saltwater_flow_mass_rate' ORDER BY time" .
 ```
 ---
 

--- a/docs/data-stream-lifecycle.md
+++ b/docs/data-stream-lifecycle.md
@@ -36,12 +36,12 @@ safe to call on every startup.
 
 ```python
 aq.insert_timeseries_batch(
-    "mybox-system-metrics",
-    {"cpu_percent": [(ts, 42.0)], "memory_percent": [(ts, 61.3)]},
+    "mybox-system-metrics", # data source name
+    {"cpu_percent": [(ts, 42.0)], "memory_percent": [(ts, 61.3)]}, # ref_name → list of (timestamp, value)
 )
 ```
 
-The handle is computed internally:
+The handle is computed internally to Acquirium:
 ```
 handle = uuid5(namespace, "mybox-system-metrics:cpu_percent")
 ```

--- a/docs/data-stream-lifecycle.md
+++ b/docs/data-stream-lifecycle.md
@@ -10,7 +10,7 @@ and queried in Acquirium.
 | `point_uri` | RDF graph (Oxigraph) | Semantic identity of the measurement. Typed, labelled, linked to equipment in your ontology. |
 | `source_id` | TimescaleDB `streams` table + RDF graph | Identifies the datasource (e.g. `"mybox-system-metrics"`). Scopes `ref_name` so two sources with the same stream name don't collide. |
 | `ref_name` | TimescaleDB `streams` table + RDF graph | Source-local stream identifier (e.g. `"cpu_percent"`). Unique within a `source_id`. |
-| `handle` | TimescaleDB `timeseries` table (storage key) | Deterministic UUID: `uuid5(namespace, f"{source_id}:{ref_name}")`. Globally unique, stable, never user-visible. |
+| `handle` | TimescaleDB `timeseries` table (storage key) | Deterministic UUID: `acq:{uuid5(namespace, f"{source_id}:{ref_name}")}` in URI format using Acquirium Namespace. Globally unique, stable, never user-visible. |
 | Brick ref node | RDF graph | An anonymous node typed as `ref:TimeseriesReference` hanging off `point_uri` via `ref:hasExternalReference`. Carries `ref:hasTimeseriesId` (the handle), `acquirium:sourceId`, `acquirium:refName`, and `ref:storedAt`. |
 
 `point_uri` and (`source_id`, `ref_name`) are intentionally separate. The
@@ -43,7 +43,7 @@ aq.insert_timeseries_batch(
 
 The handle is computed internally to Acquirium:
 ```
-handle = uuid5(namespace, "mybox-system-metrics:cpu_percent")
+handle = acq:{uuid5(namespace, "mybox-system-metrics:cpu_percent")}
 ```
 
 Rows are written to TimescaleDB keyed by this handle. The data exists in
@@ -70,11 +70,11 @@ This inserts RDF triples into Oxigraph following the
     a acquirium:VirtualPoint ;
     rdfs:label "CPU usage" ;
     qudt:hasUnit qudt-unit:PERCENT ;
-    ref:hasExternalReference <urn:host:mybox:cpu_percent#ref> .
+    ref:hasExternalReference <handle> .
 
-<urn:host:mybox:cpu_percent#ref>
+<handle>
     a ref:TimeseriesReference ;
-    ref:hasTimeseriesId  "<uuid>" ;        # = handle
+    ref:hasTimeseriesId  <handle> ;        # = handle
     acquirium:sourceId   "mybox-system-metrics" ;
     acquirium:refName    "cpu_percent" ;
     ref:storedAt         <urn:acquirium#timescaledb> .
@@ -119,7 +119,7 @@ The `scripts/publish_system_metrics.py` script follows this pattern:
 source_id  =  "mybox-system-metrics"
 ref_name   =  "cpu_percent"
 point_uri  =  "urn:host:mybox:cpu_percent"   (s223:Property in the graph)
-handle     =  uuid5(ns, "mybox-system-metrics:cpu_percent")  (TimescaleDB key)
+handle     =  acq:uuid5(ns, "mybox-system-metrics:cpu_percent")  (TimescaleDB key)
 ```
 
 1. `register_datasource()` registers the datasource node in the graph.

--- a/docs/data-stream-lifecycle.md
+++ b/docs/data-stream-lifecycle.md
@@ -1,0 +1,100 @@
+# Data Stream Lifecycle
+
+This document describes how a timeseries data stream is created, registered,
+and queried in Acquirium.
+
+## Concepts
+
+| Term | Where it lives | Description |
+|---|---|---|
+| `point_uri` | RDF graph (Oxigraph) | Semantic identity of the measurement. This is the URI your ontology knows about — typed, labelled, linked to equipment. |
+| `ref_uri` | TimescaleDB + RDF graph | Storage key. Data rows are written and read using this URI. Also appears in the graph as the object of `acquirium:hasExternalReference`. |
+| External reference node | RDF graph | The `ref_uri` itself, typed as `acquirium:TimeseriesStream`. Describes *where* the data lives. |
+
+`point_uri` and `ref_uri` are intentionally separate. The semantic identity of
+a measurement can remain stable even if the backing store, ingestion method, or
+data source changes — only the external reference needs updating.
+
+## Lifecycle
+
+### 1. Push data → establishes `ref_uri` in TimescaleDB
+
+```
+POST /insert_timeseries_batch
+{ "urn:host:mybox:cpu_percent:acquirium-ref": [["2024-01-01T00:00:00Z", 42.0]] }
+```
+
+This writes a row to TimescaleDB keyed by the `ref_uri`.  At this point the
+data exists in storage but has no semantic context — the graph knows nothing
+about it yet.
+
+### 2. Register metadata → establishes `point_uri` in the graph
+
+```python
+aq.register_stream(
+    "urn:host:mybox:cpu_percent",          # point_uri
+    label="CPU usage",
+    unit="%",
+    external_reference="urn:host:mybox:cpu_percent:acquirium-ref",  # ref_uri
+)
+```
+
+This inserts RDF triples into Oxigraph:
+
+```turtle
+<urn:host:mybox:cpu_percent>
+    a acquirium:VirtualPoint ;
+    rdfs:label "CPU usage" ;
+    qudt:hasUnit qudt-unit:PERCENT ;
+    acquirium:hasExternalReference <urn:host:mybox:cpu_percent:acquirium-ref> .
+
+<urn:host:mybox:cpu_percent:acquirium-ref>
+    a acquirium:Stream, acquirium:TimeseriesStream ;
+    acquirium:storageBackend "timescale" .
+```
+
+The `ref_uri` is the bridge: it is the graph node *and* the TimescaleDB key.
+
+### 3. Query → graph traversal joins to TimescaleDB
+
+When `.data()` is called on a query that resolves to `urn:host:mybox:cpu_percent`,
+the query layer:
+
+1. Finds `point_uri` via SPARQL against the graph
+2. Follows `acquirium:hasExternalReference` to get `ref_uri`
+3. Fetches rows from TimescaleDB where `point_uri = ref_uri`
+
+```
+graph:  <point_uri> --hasExternalReference--> <ref_uri>
+                                                  |
+timescale:                             rows keyed by ref_uri
+```
+
+## Example: system metrics script
+
+The `scripts/publish_system_metrics.py` script follows this pattern:
+
+```
+urn:host:mybox:cpu_percent              ← point_uri  (graph, s223:Property)
+urn:host:mybox:cpu_percent:acquirium-ref ← ref_uri   (TimescaleDB key + graph node)
+```
+
+1. `register_host_graph()` inserts the host as `s223:Computer` with
+   `s223:hasProperty` links to each `point_uri`, and wires each
+   `point_uri → hasExternalReference → ref_uri`.
+2. `register_stream_metadata()` resolves and attaches QUDT unit/quantity-kind
+   triples to each `point_uri`.
+3. `collect()` returns data keyed by `ref_uri` — the TimescaleDB storage key.
+4. `insert_timeseries_batch()` writes rows to TimescaleDB under those keys.
+
+## When `point_uri` and `ref_uri` can differ
+
+Keeping them separate pays off when the data source changes:
+
+- **MQTT ingestion**: `ref_uri` is the MQTT reference node carrying broker/topic.
+  The `point_uri` (the sensor in your ontology) never changes.
+- **CSV import**: `ref_uri` is a `acquirium:CSVReference` node with a file path.
+  Reimport from a new file by updating the reference, not the ontology.
+- **Direct push**: For simple cases (like this script) they can share a base name
+  but should still be distinct URIs so the graph's external reference pattern
+  remains consistent and queryable.

--- a/docs/data-stream-lifecycle.md
+++ b/docs/data-stream-lifecycle.md
@@ -7,94 +7,140 @@ and queried in Acquirium.
 
 | Term | Where it lives | Description |
 |---|---|---|
-| `point_uri` | RDF graph (Oxigraph) | Semantic identity of the measurement. This is the URI your ontology knows about — typed, labelled, linked to equipment. |
-| `ref_uri` | TimescaleDB + RDF graph | Storage key. Data rows are written and read using this URI. Also appears in the graph as the object of `acquirium:hasExternalReference`. |
-| External reference node | RDF graph | The `ref_uri` itself, typed as `acquirium:TimeseriesStream`. Describes *where* the data lives. |
+| `point_uri` | RDF graph (Oxigraph) | Semantic identity of the measurement. Typed, labelled, linked to equipment in your ontology. |
+| `source_id` | TimescaleDB `streams` table + RDF graph | Identifies the datasource (e.g. `"mybox-system-metrics"`). Scopes `ref_name` so two sources with the same stream name don't collide. |
+| `ref_name` | TimescaleDB `streams` table + RDF graph | Source-local stream identifier (e.g. `"cpu_percent"`). Unique within a `source_id`. |
+| `handle` | TimescaleDB `timeseries` table (storage key) | Deterministic UUID: `uuid5(namespace, f"{source_id}:{ref_name}")`. Globally unique, stable, never user-visible. |
+| Brick ref node | RDF graph | An anonymous node typed as `ref:TimeseriesReference` hanging off `point_uri` via `ref:hasExternalReference`. Carries `ref:hasTimeseriesId` (the handle), `acquirium:sourceId`, `acquirium:refName`, and `ref:storedAt`. |
 
-`point_uri` and `ref_uri` are intentionally separate. The semantic identity of
-a measurement can remain stable even if the backing store, ingestion method, or
-data source changes — only the external reference needs updating.
+`point_uri` and (`source_id`, `ref_name`) are intentionally separate. The
+semantic identity of a measurement stays stable even if the datasource is
+renamed, replaced, or re-ingested — only the external reference needs updating.
+
+The `handle` is an implementation detail of the storage layer. It exists solely
+to avoid key collisions when multiple datasources publish the same `ref_name`.
+Users never construct or see it directly.
 
 ## Lifecycle
 
-### 1. Push data → establishes `ref_uri` in TimescaleDB
-
-```
-POST /insert_timeseries_batch
-{ "urn:host:mybox:cpu_percent:acquirium-ref": [["2024-01-01T00:00:00Z", 42.0]] }
-```
-
-This writes a row to TimescaleDB keyed by the `ref_uri`.  At this point the
-data exists in storage but has no semantic context — the graph knows nothing
-about it yet.
-
-### 2. Register metadata → establishes `point_uri` in the graph
+### 1. Register the datasource
 
 ```python
-aq.register_stream(
-    "urn:host:mybox:cpu_percent",          # point_uri
-    label="CPU usage",
-    unit="%",
-    external_reference="urn:host:mybox:cpu_percent:acquirium-ref",  # ref_uri
+aq.register_datasource("mybox-system-metrics")
+```
+
+Writes a graph node typed as `acquirium:DataSourceRegistry`. Idempotent —
+safe to call on every startup.
+
+### 2. Insert data → rows land in TimescaleDB under the handle
+
+```python
+aq.insert_timeseries_batch(
+    "mybox-system-metrics",
+    {"cpu_percent": [(ts, 42.0)], "memory_percent": [(ts, 61.3)]},
 )
 ```
 
-This inserts RDF triples into Oxigraph:
+The handle is computed internally:
+```
+handle = uuid5(namespace, "mybox-system-metrics:cpu_percent")
+```
+
+Rows are written to TimescaleDB keyed by this handle. The data exists in
+storage but has no semantic context yet — the graph knows nothing about it.
+
+### 3. Register metadata → establishes `point_uri` in the graph
+
+```python
+aq.register_stream(
+    "urn:host:mybox:cpu_percent",   # point_uri
+    label="CPU usage",
+    unit="%",
+    quantity_kind="dimensionless ratio",
+    source_id="mybox-system-metrics",
+    ref_name="cpu_percent",
+)
+```
+
+This inserts RDF triples into Oxigraph following the
+[Brick timeseries storage spec](https://docs.brickschema.org/metadata/timeseries-storage.html):
 
 ```turtle
 <urn:host:mybox:cpu_percent>
     a acquirium:VirtualPoint ;
     rdfs:label "CPU usage" ;
     qudt:hasUnit qudt-unit:PERCENT ;
-    acquirium:hasExternalReference <urn:host:mybox:cpu_percent:acquirium-ref> .
+    ref:hasExternalReference <urn:host:mybox:cpu_percent#ref> .
 
-<urn:host:mybox:cpu_percent:acquirium-ref>
-    a acquirium:Stream, acquirium:TimeseriesStream ;
-    acquirium:storageBackend "timescale" .
+<urn:host:mybox:cpu_percent#ref>
+    a ref:TimeseriesReference ;
+    ref:hasTimeseriesId  "<uuid>" ;        # = handle
+    acquirium:sourceId   "mybox-system-metrics" ;
+    acquirium:refName    "cpu_percent" ;
+    ref:storedAt         <urn:acquirium:timescaledb> .
+
+<urn:acquirium:timescaledb>  a  ref:Database .
 ```
 
-The `ref_uri` is the bridge: it is the graph node *and* the TimescaleDB key.
-
-### 3. Query → graph traversal joins to TimescaleDB
-
-When `.data()` is called on a query that resolves to `urn:host:mybox:cpu_percent`,
-the query layer:
-
-1. Finds `point_uri` via SPARQL against the graph
-2. Follows `acquirium:hasExternalReference` to get `ref_uri`
-3. Fetches rows from TimescaleDB where `point_uri = ref_uri`
+When this graph is inserted, the server scans for `acquirium:sourceId` /
+`acquirium:refName` pairs and populates the `streams` table:
 
 ```
-graph:  <point_uri> --hasExternalReference--> <ref_uri>
-                                                  |
-timescale:                             rows keyed by ref_uri
+streams: handle → (point_uri, source_id, ref_name)
 ```
+
+This is the bridge that lets reads resolve a semantic URI back to data.
+
+### 4. Query → point_uri resolves to handle, then to rows
+
+When `.data()` is called on a query that resolves to
+`urn:host:mybox:cpu_percent`, the server:
+
+1. Looks up `point_uri` in the `streams` table → gets `handle`
+2. Fetches rows from TimescaleDB where `point_uri = handle`
+
+```
+graph:  <point_uri> --ref:hasExternalReference--> <ref_node>
+                                                       |
+streams table:  point_uri  ──────────────────────>  handle
+                                                       |
+timescale:                                    rows keyed by handle
+```
+
+If a `point_uri` is not in the `streams` table (e.g. data inserted via the
+bulk CSV path), the server falls back to querying TimescaleDB directly by
+`point_uri`, preserving backwards compatibility with older ingestion paths.
 
 ## Example: system metrics script
 
 The `scripts/publish_system_metrics.py` script follows this pattern:
 
 ```
-urn:host:mybox:cpu_percent              ← point_uri  (graph, s223:Property)
-urn:host:mybox:cpu_percent:acquirium-ref ← ref_uri   (TimescaleDB key + graph node)
+source_id  =  "mybox-system-metrics"
+ref_name   =  "cpu_percent"
+point_uri  =  "urn:host:mybox:cpu_percent"   (s223:Property in the graph)
+handle     =  uuid5(ns, "mybox-system-metrics:cpu_percent")  (TimescaleDB key)
 ```
 
-1. `register_host_graph()` inserts the host as `s223:Computer` with
-   `s223:hasProperty` links to each `point_uri`, and wires each
-   `point_uri → hasExternalReference → ref_uri`.
-2. `register_stream_metadata()` resolves and attaches QUDT unit/quantity-kind
+1. `register_datasource()` registers the datasource node in the graph.
+2. `register_host_graph()` inserts the host as `s223:Computer` with
+   `s223:hasProperty` links to each `point_uri`, and attaches a Brick
+   `ref:TimeseriesReference` node to each stream.
+3. `register_stream_metadata()` resolves and attaches QUDT unit / quantity-kind
    triples to each `point_uri`.
-3. `collect()` returns data keyed by `ref_uri` — the TimescaleDB storage key.
-4. `insert_timeseries_batch()` writes rows to TimescaleDB under those keys.
+4. `collect()` returns samples keyed by `ref_name`.
+5. `insert_timeseries_batch()` computes handles and writes rows to TimescaleDB.
 
-## When `point_uri` and `ref_uri` can differ
+## Why keep `point_uri` and `(source_id, ref_name)` separate?
 
-Keeping them separate pays off when the data source changes:
-
-- **MQTT ingestion**: `ref_uri` is the MQTT reference node carrying broker/topic.
-  The `point_uri` (the sensor in your ontology) never changes.
-- **CSV import**: `ref_uri` is a `acquirium:CSVReference` node with a file path.
-  Reimport from a new file by updating the reference, not the ontology.
-- **Direct push**: For simple cases (like this script) they can share a base name
-  but should still be distinct URIs so the graph's external reference pattern
-  remains consistent and queryable.
+- **MQTT ingestion**: the MQTT topic is the `ref_name`; the sensor URI in your
+  ontology is the `point_uri`. Replace the broker or topic without touching
+  the ontology.
+- **CSV import**: `ref_name` identifies the column; the `point_uri` is the
+  sensor. Re-import from a revised file without changing any semantic triples.
+- **Multiple sources, same stream name**: Two loggers both publishing
+  `"temperature"` get different handles because they have different
+  `source_id`s. No collision, no overwritten data.
+- **Stable queries**: application code queries by `point_uri`. The storage
+  plumbing (`source_id`, `ref_name`, `handle`) can change without breaking
+  any query.

--- a/docs/data-stream-lifecycle.md
+++ b/docs/data-stream-lifecycle.md
@@ -77,9 +77,9 @@ This inserts RDF triples into Oxigraph following the
     ref:hasTimeseriesId  "<uuid>" ;        # = handle
     acquirium:sourceId   "mybox-system-metrics" ;
     acquirium:refName    "cpu_percent" ;
-    ref:storedAt         <urn:acquirium:timescaledb> .
+    ref:storedAt         <urn:acquirium#timescaledb> .
 
-<urn:acquirium:timescaledb>  a  ref:Database .
+<urn:acquirium#timescaledb>  a <urn:acquirium#Database> .
 ```
 
 When this graph is inserted, the server scans for `acquirium:sourceId` /

--- a/ontologies/ref-schema.ttl
+++ b/ontologies/ref-schema.ttl
@@ -27,57 +27,11 @@ ref:ExternalReferenceShape a sh:NodeShape ;
             sh:path rdfs:label ] ;
     sh:target [ a sh:SPARQLTarget ;
             sh:prefixes <https://brickschema.org/schema/Brick/ref> ;
-            sh:select """
-    SELECT ?this WHERE {
-     ?this rdfs:subClassOf+ ref:ExternalReference .
-    }
+            sh:select """\r
+    SELECT ?this WHERE {\r
+     ?this rdfs:subClassOf+ ref:ExternalReference .\r
+    }\r
     """^^xsd:string ] .
-
-ref:HTTPHeaderShape a sh:NodeShape ;
-    skos:definition "Shape for validating HTTP headers."^^xsd:string ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path ref:httpHeaderName ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path ref:httpHeaderValue ] ;
-    sh:targetClass ref:HTTPHeader .
-
-ref:HTTPQueryParameterShape a sh:NodeShape ;
-    skos:definition "Shape for validating HTTP query parameters."^^xsd:string ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path ref:httpParamName ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path ref:httpParamValue ] ;
-    sh:targetClass ref:HTTPQueryParameter .
-
-ref:HTTPReferenceShape a sh:NodeShape ;
-    skos:definition "Infers an HTTPReference instance from the object of an hasExternalReference when httpBaseUrl is present."^^xsd:string ;
-    sh:rule [ a sh:TripleRule ;
-            sh:condition [ sh:property [ sh:minCount 1 ;
-                            sh:path ref:httpBaseUrl ] ] ;
-            sh:object ref:HTTPReference ;
-            sh:predicate rdf:type ;
-            sh:subject sh:this ] ;
-    sh:targetObjectsOf ref:hasExternalReference .
-
-ref:HTTPTimeseriesReferenceShape a sh:NodeShape ;
-    skos:definition "Infers an HTTPTimeseriesReference instance from the object of an hasExternalReference when httpBaseUrl and hasTimeseriesId are present."^^xsd:string ;
-    sh:rule [ a sh:TripleRule ;
-            sh:condition [ sh:property [ sh:minCount 1 ;
-                            sh:path ref:httpBaseUrl ],
-                        [ sh:minCount 1 ;
-                            sh:path ref:hasTimeseriesId ] ] ;
-            sh:object ref:HTTPTimeseriesReference ;
-            sh:predicate rdf:type ;
-            sh:subject sh:this ] ;
-    sh:targetObjectsOf ref:hasExternalReference .
 
 ref:IFCReferenceShape a sh:NodeShape ;
     skos:definition "Infers a IFCReference instance from the object of an hasExternalReference."^^xsd:string ;
@@ -106,6 +60,15 @@ ref:InfluxDBReference a owl:Class,
             sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:path ref:storedAt ] .
+
+ref:MQTTReferenceShape a sh:NodeShape ;
+    skos:definition "Infers an MQTTReference instance from the object of an hasExternalReference."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:MQTTReference ;
+            sh:object ref:MQTTReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
 
 ref:PreferredShape a sh:NodeShape ;
     sh:property [ sh:message "An entity can only have one 'preferred' External Reference"^^xsd:string ;
@@ -139,19 +102,41 @@ ref:csvReferenceShape a sh:NodeShape ;
             sh:subject sh:this ] ;
     sh:targetObjectsOf ref:hasExternalReference .
 
+ref:fileReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a fileReference instance from the object of an hasExternalReference."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:FileReference ;
+            sh:object ref:FileReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
 ref:hasCsvReference a owl:ObjectProperty ;
     rdfs:label "hasCsvReference"^^xsd:string ;
     skos:definition "A reference to the CSV file that defines this entity"^^xsd:string .
 
-ref:hasHTTPReference a owl:ObjectProperty ;
-    rdfs:label "hasHTTPReference"^^xsd:string ;
+ref:hasFileReference a owl:ObjectProperty ;
+    rdfs:label "hasFileReference"^^xsd:string ;
+    rdfs:range ref:fileReference ;
     rdfs:subPropertyOf ref:hasExternalReference ;
-    skos:definition "A reference to data accessible via an HTTP API endpoint."^^xsd:string .
+    skos:definition "Relates an entity to a fileReference describing a tabular file (e.g. parquet, csv, tsv) that contains the data for this entity"^^xsd:string .
 
-ref:hasHTTPTimeseriesReference a owl:ObjectProperty ;
-    rdfs:label "hasHTTPTimeseriesReference"^^xsd:string ;
-    rdfs:subPropertyOf ref:hasTimeseriesReference ;
-    skos:definition "A reference to timeseries data accessible via an HTTP API endpoint."^^xsd:string .
+ref:hasMQTTReference a owl:ObjectProperty ;
+    rdfs:label "hasMQTTReference"^^xsd:string ;
+    rdfs:range ref:MQTTReference ;
+    rdfs:subPropertyOf ref:hasExternalReference ;
+    skos:definition "Relates an entity to an MQTTReference describing the broker and topic where data for this entity is published"^^xsd:string .
+
+ref:hasTimeseriesReference a owl:ObjectProperty ;
+    rdfs:label "hasTimeseriesReference"^^xsd:string ;
+    rdfs:range ref:TimeseriesReference ;
+    rdfs:subPropertyOf ref:hasExternalReference ;
+    skos:definition "Metadata for accessing related timeseries data: Relates a data source (such as a Brick Point or 223 Property) to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
+
+ref:timeColumnID a owl:DatatypeProperty ;
+    rdfs:label "timeColumnID"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "Name of the column in the referenced file that contains the timestamps"^^xsd:string .
 
 bacnet:description a bacnet:StandardProperty,
         owl:DatatypeProperty ;
@@ -201,31 +186,21 @@ bacnet:objectOf a owl:ObjectProperty ;
                 schemaorg:email "gtfierro@mines.edu"^^xsd:string ;
                 schemaorg:name "Gabe Fierro"^^xsd:string ] ) ;
     dcterms:title "Ref Schema"^^xsd:string ;
-    owl:versionInfo "git:HEAD@8af7aed29087cfe95bc3983c02b3f3e9bd684f2a date:2026-02-02T09:23:05-07:00" ;
-    sh:declare [ sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
-            sh:prefix "sh"^^xsd:string ],
-        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
-            sh:prefix "rdf"^^xsd:string ],
+    owl:versionInfo "git:ums-file-pg-addition@89cd28f1408a23f99e850fd6042ab44cc9564890 date:2026-04-25T01:41:59+03:00" ;
+    sh:declare [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+            sh:prefix "owl"^^xsd:string ],
         [ sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
             sh:prefix "rdfs"^^xsd:string ],
-        [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
-            sh:prefix "owl"^^xsd:string ],
+        [ sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+            sh:prefix "sh"^^xsd:string ],
         [ sh:namespace "https://brickschema.org/schema/Brick/ref#"^^xsd:anyURI ;
-            sh:prefix "ref"^^xsd:string ] .
+            sh:prefix "ref"^^xsd:string ],
+        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+            sh:prefix "rdf"^^xsd:string ] .
 
 ref:BACnetURI a owl:DatatypeProperty ;
     rdfs:label "BACnetURI"^^xsd:string ;
     rdfs:comment "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]"^^xsd:string .
-
-ref:HTTPTimeseriesReference a owl:Class,
-        sh:NodeShape ;
-    rdfs:label "HTTP Timeseries Reference"^^xsd:string ;
-    rdfs:subClassOf ref:HTTPReference,
-        ref:TimeseriesReference ;
-    skos:definition "A reference to timeseries data accessible via an HTTP API endpoint."^^xsd:string ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:path ref:httpResponsePath ] .
 
 ref:InfluxDBServer a owl:Class,
         sh:NodeShape ;
@@ -238,14 +213,24 @@ ref:InfluxDBServer a owl:Class,
             sh:path ref:influxDBUrl ],
         [ sh:datatype xsd:string ;
             sh:minCount 1 ;
-            sh:path ref:influxDBTokenLocation ],
+            sh:path ref:influxDBAuthenticationMethod ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:path ref:influxDBOrg ],
         [ sh:datatype xsd:string ;
             sh:minCount 1 ;
-            sh:path ref:influxDBAuthenticationMethod ] .
+            sh:path ref:influxDBTokenLocation ] .
+
+ref:MQTTBroker a owl:DatatypeProperty ;
+    rdfs:label "MQTTBroker"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "Address of the MQTT broker (e.g. host, host:port, or mqtt(s):// URI) that hosts the topic for this reference"^^xsd:string .
+
+ref:MQTTTopic a owl:DatatypeProperty ;
+    rdfs:label "MQTTTopic"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "Topic string on the MQTT broker that carries the messages for this entity"^^xsd:string .
 
 ref:csvColumnID a owl:DatatypeProperty ;
     rdfs:label "The column name of the CSV reference as defined in the file"^^xsd:string ;
@@ -255,60 +240,18 @@ ref:csvFileLocation a owl:DatatypeProperty ;
     rdfs:label "The Location of the CSV file"^^xsd:string ;
     rdfs:range xsd:string .
 
-ref:hasHTTPHeader a owl:ObjectProperty ;
-    rdfs:label "has HTTP Header"^^xsd:string ;
-    rdfs:range ref:HTTPHeader ;
-    skos:definition "Links to an HTTP header key-value pair."^^xsd:string .
-
-ref:hasHTTPQueryParam a owl:ObjectProperty ;
-    rdfs:label "has HTTP Query Parameter"^^xsd:string ;
-    rdfs:range ref:HTTPQueryParameter ;
-    skos:definition "Links to an HTTP query parameter key-value pair."^^xsd:string .
+ref:fileLocation a owl:DatatypeProperty ;
+    rdfs:label "fileLocation"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "Path or URI identifying the location of the referenced file"^^xsd:string .
 
 ref:hasIfcProjectReference a owl:ObjectProperty ;
     rdfs:label "hasIfcProjectReference"^^xsd:string ;
     skos:definition "A reference to the IFC Project that defines this entity"^^xsd:string .
 
-ref:hasTimeseriesReference a owl:ObjectProperty ;
-    rdfs:label "hasTimeseriesReference"^^xsd:string ;
-    rdfs:range ref:TimeseriesReference ;
-    rdfs:subPropertyOf ref:hasExternalReference ;
-    skos:definition "Metadata for accessing related timeseries data: Relates a data source (such as a Brick Point or 223 Property) to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
-
-ref:httpContentType a owl:DatatypeProperty ;
-    rdfs:label "HTTP Content Type"^^xsd:string ;
-    rdfs:range xsd:string ;
-    skos:definition "The expected content type of the response (e.g., application/json, text/csv)."^^xsd:string .
-
-ref:httpHeaderName a owl:DatatypeProperty ;
-    rdfs:label "HTTP Header Name"^^xsd:string ;
-    rdfs:range xsd:string ;
-    skos:definition "The name of an HTTP header."^^xsd:string .
-
-ref:httpHeaderValue a owl:DatatypeProperty ;
-    rdfs:label "HTTP Header Value"^^xsd:string ;
-    rdfs:range xsd:string ;
-    skos:definition "The value of an HTTP header. Use env: or $ prefix to reference environment variables. Never store secrets in plaintext."^^xsd:string .
-
-ref:httpMethod a owl:DatatypeProperty ;
-    rdfs:label "HTTP Method"^^xsd:string ;
-    rdfs:range xsd:string ;
-    skos:definition "The HTTP method to use for the request (GET, POST, PUT, DELETE, etc.). Defaults to GET if not specified."^^xsd:string .
-
-ref:httpParamName a owl:DatatypeProperty ;
-    rdfs:label "HTTP Parameter Name"^^xsd:string ;
-    rdfs:range xsd:string ;
-    skos:definition "The name (key) of an HTTP query parameter."^^xsd:string .
-
-ref:httpParamValue a owl:DatatypeProperty ;
-    rdfs:label "HTTP Parameter Value"^^xsd:string ;
-    rdfs:range xsd:string ;
-    skos:definition "The value of an HTTP query parameter. Use env: or $ prefix to reference environment variables."^^xsd:string .
-
-ref:httpResponsePath a owl:DatatypeProperty ;
-    rdfs:label "HTTP Response Path"^^xsd:string ;
-    rdfs:range xsd:string ;
-    skos:definition "A JSONPath or similar expression for extracting data from the HTTP response."^^xsd:string .
+ref:hasTimeseriesId a owl:DatatypeProperty ;
+    rdfs:label "hasTimeseriesId"^^xsd:string ;
+    skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
 
 ref:ifcFileLocation a owl:DatatypeProperty ;
     rdfs:label "The location of the IFC file defining a project"^^xsd:string ;
@@ -341,30 +284,35 @@ ref:ifcProjectID a owl:DatatypeProperty ;
 ref:preferred a owl:DatatypeProperty ;
     skos:definition "An entity can have one 'preferred' External Reference. Consumers of the model should prioritize any external reference with the 'preferred' property"^^xsd:string .
 
+ref:valueColumnID a owl:DatatypeProperty ;
+    rdfs:label "valueColumnID"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "Name of the column in the referenced file that contains the values"^^xsd:string .
+
 ref:BACnetReference a owl:Class,
         sh:NodeShape ;
     rdfs:label "BACnet Reference"^^xsd:string ;
     rdfs:subClassOf ref:ExternalReference ;
     skos:definition "A reference to the BACnet object represented by this entity."^^xsd:string ;
     sh:or ( [ sh:property [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:description ],
+                    [ a sh:PropertyShape ;
                         sh:class bacnet:EngineeringUnitsEnumerationValue ;
                         sh:maxCount 1 ;
                         sh:minCount 0 ;
                         sh:path bacnet:units ],
                     [ a sh:PropertyShape ;
                         sh:datatype xsd:string ;
-                        sh:minCount 1 ;
-                        sh:path bacnet:object-identifier ],
+                        sh:path bacnet:object-type ],
                     [ a sh:PropertyShape ;
                         sh:datatype xsd:string ;
-                        sh:path bacnet:object-type ],
+                        sh:minCount 1 ;
+                        sh:path bacnet:object-identifier ],
                     [ a sh:PropertyShape ;
                         sh:datatype bacnet:Property ;
                         sh:defaultValue bacnet:Present_Value ;
                         sh:path ref:read-property ],
-                    [ a sh:PropertyShape ;
-                        sh:datatype xsd:string ;
-                        sh:path bacnet:description ],
                     [ a sh:PropertyShape ;
                         sh:datatype xsd:string ;
                         sh:minLength 1 ;
@@ -377,26 +325,19 @@ ref:BACnetReference a owl:Class,
             sh:minCount 1 ;
             sh:path bacnet:objectOf ] .
 
-ref:HTTPReference a owl:Class,
+ref:FileReference a owl:Class,
         sh:NodeShape ;
-    rdfs:label "HTTP Reference"^^xsd:string ;
+    rdfs:label "File Reference"^^xsd:string ;
     rdfs:subClassOf ref:ExternalReference ;
-    skos:definition "A reference to data accessible via an HTTP API endpoint."^^xsd:string ;
+    skos:definition "Refers to a tabular file (e.g. parquet, csv, tsv) that contains the timestamped values for this entity, along with the column names holding the timestamps and values"^^xsd:string ;
     sh:property [ sh:datatype xsd:string ;
-            sh:in ( "GET"^^xsd:string "POST"^^xsd:string "PUT"^^xsd:string ) ;
-            sh:maxCount 1 ;
-            sh:path ref:httpMethod ],
-        [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:httpBaseUrl ],
+            sh:path ref:valueColumnID ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
-            sh:path ref:httpContentType ],
-        [ sh:class ref:HTTPQueryParameter ;
-            sh:path ref:hasHTTPQueryParam ],
-        [ sh:class ref:HTTPHeader ;
-            sh:path ref:hasHTTPHeader ] .
+            sh:minCount 1 ;
+            sh:path ref:fileLocation ] .
 
 ref:IFCReference a owl:Class,
         sh:NodeShape ;
@@ -404,11 +345,6 @@ ref:IFCReference a owl:Class,
     rdfs:subClassOf ref:ExternalReference ;
     skos:definition "A reference to an entity in an IFC project which may contain additional metadata about this entity."^^xsd:string ;
     sh:property [ a sh:PropertyShape ;
-            skos:definition "Reference to an IFC Project object, containing the project ID"^^xsd:string ;
-            sh:class ref:ifcProject ;
-            sh:minCount 1 ;
-            sh:path ref:hasIfcProjectReference ],
-        [ a sh:PropertyShape ;
             skos:definition "The global ID of the entity in the IFC project"^^xsd:string ;
             sh:datatype xsd:string ;
             sh:minCount 1 ;
@@ -416,7 +352,12 @@ ref:IFCReference a owl:Class,
         [ a sh:PropertyShape ;
             skos:definition "Name of the entity in IFC"^^xsd:string ;
             sh:datatype xsd:string ;
-            sh:path ref:ifcName ] .
+            sh:path ref:ifcName ],
+        [ a sh:PropertyShape ;
+            skos:definition "Reference to an IFC Project object, containing the project ID"^^xsd:string ;
+            sh:class ref:ifcProject ;
+            sh:minCount 1 ;
+            sh:path ref:hasIfcProjectReference ] .
 
 ref:csvReference a owl:Class,
         sh:NodeShape ;
@@ -430,32 +371,23 @@ ref:csvReference a owl:Class,
             sh:minCount 1 ;
             sh:path ref:csvFileLocation ] .
 
-ref:hasTimeseriesId a owl:DatatypeProperty ;
-    rdfs:label "hasTimeseriesId"^^xsd:string ;
-    skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
-
 ref:storedAt a owl:DatatypeProperty ;
     rdfs:label "storedAt"^^xsd:string ;
     skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
 
-ref:HTTPHeader a owl:Class ;
-    rdfs:label "HTTP Header"^^xsd:string ;
-    skos:definition "A key-value pair representing an HTTP header."^^xsd:string .
-
-ref:HTTPQueryParameter a owl:Class ;
-    rdfs:label "HTTP Query Parameter"^^xsd:string ;
-    skos:definition "A key-value pair representing an HTTP query parameter."^^xsd:string .
-
-ref:httpBaseUrl a owl:DatatypeProperty ;
-    rdfs:label "HTTP Base URL"^^xsd:string ;
-    rdfs:range xsd:anyURI ;
-    skos:definition "The base URL of the HTTP API endpoint, excluding query parameters."^^xsd:string .
-
-ref:ExternalReference a owl:Class,
+ref:MQTTReference a owl:Class,
         sh:NodeShape ;
-    rdfs:label "External reference"^^xsd:string ;
-    rdfs:subClassOf <http://data.ashrae.org/standard223#ExternalReference> ;
-    skos:definition "The parent class of all external reference types"^^xsd:string .
+    rdfs:label "MQTT Reference"^^xsd:string ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "Refers to an MQTT stream identified by a broker and topic that this entity publishes to or consumes from"^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:MQTTTopic ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:MQTTBroker ] .
 
 ref:TimeseriesReference a owl:Class,
         sh:NodeShape ;
@@ -471,6 +403,12 @@ ref:TimeseriesReference a owl:Class,
             sh:datatype xsd:string ;
             sh:minCount 1 ;
             sh:path ref:hasTimeseriesId ] .
+
+ref:ExternalReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "External reference"^^xsd:string ;
+    rdfs:subClassOf <http://data.ashrae.org/standard223#ExternalReference> ;
+    skos:definition "The parent class of all external reference types"^^xsd:string .
 
 ref:hasExternalReference a owl:ObjectProperty ;
     rdfs:label "hasExternalReference"^^xsd:string ;

--- a/ontologies/ref-schema.ttl
+++ b/ontologies/ref-schema.ttl
@@ -19,12 +19,12 @@ ref:BACnetReferenceShape a sh:NodeShape ;
     sh:targetObjectsOf ref:hasExternalReference .
 
 ref:ExternalReferenceShape a sh:NodeShape ;
-    sh:property [ sh:message "All ExternalReference must have an skos:definition"^^xsd:string ;
+    sh:property [ sh:message "All ExternalReference must have an rdfs:label"^^xsd:string ;
             sh:minCount 1 ;
-            sh:path skos:definition ],
-        [ sh:message "All ExternalReference must have an rdfs:label"^^xsd:string ;
+            sh:path rdfs:label ],
+        [ sh:message "All ExternalReference must have an skos:definition"^^xsd:string ;
             sh:minCount 1 ;
-            sh:path rdfs:label ] ;
+            sh:path skos:definition ] ;
     sh:target [ a sh:SPARQLTarget ;
             sh:prefixes <https://brickschema.org/schema/Brick/ref> ;
             sh:select """\r
@@ -32,6 +32,15 @@ ref:ExternalReferenceShape a sh:NodeShape ;
      ?this rdfs:subClassOf+ ref:ExternalReference .\r
     }\r
     """^^xsd:string ] .
+
+ref:FileReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a FileReference instance from the object of an hasExternalReference."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:FileReference ;
+            sh:object ref:FileReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
 
 ref:IFCReferenceShape a sh:NodeShape ;
     skos:definition "Infers a IFCReference instance from the object of an hasExternalReference."^^xsd:string ;
@@ -47,19 +56,19 @@ ref:InfluxDBReference a owl:Class,
     rdfs:label "InfluxDB Record Reference"^^xsd:string ;
     rdfs:subClassOf ref:TimeseriesReference ;
     skos:definition "Refers to an InfluxDB measurement within a bucket, stored on an InfluxDB server."^^xsd:string ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:property [ sh:class ref:InfluxDBServer ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ref:storedAt ],
+        [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:path ref:influxDBMeasurement ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:influxDBBucket ],
-        [ sh:class ref:InfluxDBServer ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path ref:storedAt ] .
+            sh:path ref:influxDBBucket ] .
 
 ref:MQTTReferenceShape a sh:NodeShape ;
     skos:definition "Infers an MQTTReference instance from the object of an hasExternalReference."^^xsd:string ;
@@ -102,24 +111,15 @@ ref:csvReferenceShape a sh:NodeShape ;
             sh:subject sh:this ] ;
     sh:targetObjectsOf ref:hasExternalReference .
 
-ref:fileReferenceShape a sh:NodeShape ;
-    skos:definition "Infers a fileReference instance from the object of an hasExternalReference."^^xsd:string ;
-    sh:rule [ a sh:TripleRule ;
-            sh:condition ref:FileReference ;
-            sh:object ref:FileReference ;
-            sh:predicate rdf:type ;
-            sh:subject sh:this ] ;
-    sh:targetObjectsOf ref:hasExternalReference .
-
 ref:hasCsvReference a owl:ObjectProperty ;
     rdfs:label "hasCsvReference"^^xsd:string ;
     skos:definition "A reference to the CSV file that defines this entity"^^xsd:string .
 
 ref:hasFileReference a owl:ObjectProperty ;
     rdfs:label "hasFileReference"^^xsd:string ;
-    rdfs:range ref:fileReference ;
+    rdfs:range ref:FileReference ;
     rdfs:subPropertyOf ref:hasExternalReference ;
-    skos:definition "Relates an entity to a fileReference describing a tabular file (e.g. parquet, csv, tsv) that contains the data for this entity"^^xsd:string .
+    skos:definition "Relates an entity to a FileReference describing a tabular file (e.g. parquet, csv, tsv) that contains the data for this entity"^^xsd:string .
 
 ref:hasMQTTReference a owl:ObjectProperty ;
     rdfs:label "hasMQTTReference"^^xsd:string ;
@@ -186,17 +186,17 @@ bacnet:objectOf a owl:ObjectProperty ;
                 schemaorg:email "gtfierro@mines.edu"^^xsd:string ;
                 schemaorg:name "Gabe Fierro"^^xsd:string ] ) ;
     dcterms:title "Ref Schema"^^xsd:string ;
-    owl:versionInfo "git:ums-file-pg-addition@89cd28f1408a23f99e850fd6042ab44cc9564890 date:2026-04-25T01:41:59+03:00" ;
-    sh:declare [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
-            sh:prefix "owl"^^xsd:string ],
-        [ sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
-            sh:prefix "rdfs"^^xsd:string ],
+    owl:versionInfo "git:ums-file-pg-addition@d546b61a873153d0c9f0b21b88d462d691ba6794 date:2026-04-25T01:54:21+03:00" ;
+    sh:declare [ sh:namespace "https://brickschema.org/schema/Brick/ref#"^^xsd:anyURI ;
+            sh:prefix "ref"^^xsd:string ],
         [ sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
             sh:prefix "sh"^^xsd:string ],
-        [ sh:namespace "https://brickschema.org/schema/Brick/ref#"^^xsd:anyURI ;
-            sh:prefix "ref"^^xsd:string ],
+        [ sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
+            sh:prefix "rdfs"^^xsd:string ],
         [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
-            sh:prefix "rdf"^^xsd:string ] .
+            sh:prefix "rdf"^^xsd:string ],
+        [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+            sh:prefix "owl"^^xsd:string ] .
 
 ref:BACnetURI a owl:DatatypeProperty ;
     rdfs:label "BACnetURI"^^xsd:string ;
@@ -207,13 +207,13 @@ ref:InfluxDBServer a owl:Class,
     rdfs:label "InfluxDB Database Server Reference"^^xsd:string ;
     rdfs:comment "A reference to an InfluxDB database server."^^xsd:string ;
     skos:definition "Refers to an InfluxDB database server"^^xsd:string ;
-    sh:property [ sh:datatype xsd:anyURI ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:influxDBAuthenticationMethod ],
+        [ sh:datatype xsd:anyURI ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:path ref:influxDBUrl ],
-        [ sh:datatype xsd:string ;
-            sh:minCount 1 ;
-            sh:path ref:influxDBAuthenticationMethod ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
@@ -271,11 +271,11 @@ ref:ifcProject a owl:Class,
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:ifcProjectID ],
+            sh:path ref:ifcFileLocation ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:ifcFileLocation ] .
+            sh:path ref:ifcProjectID ] .
 
 ref:ifcProjectID a owl:DatatypeProperty ;
     rdfs:label "ifcProjectID"^^xsd:string ;
@@ -295,28 +295,28 @@ ref:BACnetReference a owl:Class,
     rdfs:subClassOf ref:ExternalReference ;
     skos:definition "A reference to the BACnet object represented by this entity."^^xsd:string ;
     sh:or ( [ sh:property [ a sh:PropertyShape ;
+                        sh:datatype bacnet:Property ;
+                        sh:defaultValue bacnet:Present_Value ;
+                        sh:path ref:read-property ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:object-type ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minLength 1 ;
+                        sh:path bacnet:object-name ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minCount 1 ;
+                        sh:path bacnet:object-identifier ],
+                    [ a sh:PropertyShape ;
                         sh:datatype xsd:string ;
                         sh:path bacnet:description ],
                     [ a sh:PropertyShape ;
                         sh:class bacnet:EngineeringUnitsEnumerationValue ;
                         sh:maxCount 1 ;
                         sh:minCount 0 ;
-                        sh:path bacnet:units ],
-                    [ a sh:PropertyShape ;
-                        sh:datatype xsd:string ;
-                        sh:path bacnet:object-type ],
-                    [ a sh:PropertyShape ;
-                        sh:datatype xsd:string ;
-                        sh:minCount 1 ;
-                        sh:path bacnet:object-identifier ],
-                    [ a sh:PropertyShape ;
-                        sh:datatype bacnet:Property ;
-                        sh:defaultValue bacnet:Present_Value ;
-                        sh:path ref:read-property ],
-                    [ a sh:PropertyShape ;
-                        sh:datatype xsd:string ;
-                        sh:minLength 1 ;
-                        sh:path bacnet:object-name ] ] [ sh:property [ a sh:PropertyShape ;
+                        sh:path bacnet:units ] ] [ sh:property [ a sh:PropertyShape ;
                         skos:definition "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]"^^xsd:string ;
                         sh:datatype xsd:string ;
                         sh:path ref:BACnetURI ] ] ) ;
@@ -325,34 +325,20 @@ ref:BACnetReference a owl:Class,
             sh:minCount 1 ;
             sh:path bacnet:objectOf ] .
 
-ref:FileReference a owl:Class,
-        sh:NodeShape ;
-    rdfs:label "File Reference"^^xsd:string ;
-    rdfs:subClassOf ref:ExternalReference ;
-    skos:definition "Refers to a tabular file (e.g. parquet, csv, tsv) that contains the timestamped values for this entity, along with the column names holding the timestamps and values"^^xsd:string ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path ref:valueColumnID ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:path ref:fileLocation ] .
-
 ref:IFCReference a owl:Class,
         sh:NodeShape ;
     rdfs:label "Industry Foundation Classes Reference"^^xsd:string ;
     rdfs:subClassOf ref:ExternalReference ;
     skos:definition "A reference to an entity in an IFC project which may contain additional metadata about this entity."^^xsd:string ;
     sh:property [ a sh:PropertyShape ;
+            skos:definition "Name of the entity in IFC"^^xsd:string ;
+            sh:datatype xsd:string ;
+            sh:path ref:ifcName ],
+        [ a sh:PropertyShape ;
             skos:definition "The global ID of the entity in the IFC project"^^xsd:string ;
             sh:datatype xsd:string ;
             sh:minCount 1 ;
             sh:path ref:ifcGlobalID ],
-        [ a sh:PropertyShape ;
-            skos:definition "Name of the entity in IFC"^^xsd:string ;
-            sh:datatype xsd:string ;
-            sh:path ref:ifcName ],
         [ a sh:PropertyShape ;
             skos:definition "Reference to an IFC Project object, containing the project ID"^^xsd:string ;
             sh:class ref:ifcProject ;
@@ -365,15 +351,29 @@ ref:csvReference a owl:Class,
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:csvColumnID ],
+            sh:path ref:csvFileLocation ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:csvFileLocation ] .
+            sh:path ref:csvColumnID ] .
 
 ref:storedAt a owl:DatatypeProperty ;
     rdfs:label "storedAt"^^xsd:string ;
     skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
+
+ref:FileReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "File Reference"^^xsd:string ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "Refers to a tabular file (e.g. parquet, csv, tsv) that contains the timestamped values for this entity, along with the column names holding the timestamps and values"^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:fileLocation ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:valueColumnID ] .
 
 ref:MQTTReference a owl:Class,
         sh:NodeShape ;
@@ -383,11 +383,11 @@ ref:MQTTReference a owl:Class,
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:MQTTTopic ],
+            sh:path ref:MQTTBroker ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:path ref:MQTTBroker ] .
+            sh:path ref:MQTTTopic ] .
 
 ref:TimeseriesReference a owl:Class,
         sh:NodeShape ;

--- a/ontologies/ref-schema.ttl
+++ b/ontologies/ref-schema.ttl
@@ -1,0 +1,479 @@
+@prefix bacnet: <http://data.ashrae.org/bacnet/2020#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix schemaorg: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ref:BACnetReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a BACnetReference instance from the object of an hasExternalReference."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:BACnetReference ;
+            sh:object ref:BACnetReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:ExternalReferenceShape a sh:NodeShape ;
+    sh:property [ sh:message "All ExternalReference must have an skos:definition"^^xsd:string ;
+            sh:minCount 1 ;
+            sh:path skos:definition ],
+        [ sh:message "All ExternalReference must have an rdfs:label"^^xsd:string ;
+            sh:minCount 1 ;
+            sh:path rdfs:label ] ;
+    sh:target [ a sh:SPARQLTarget ;
+            sh:prefixes <https://brickschema.org/schema/Brick/ref> ;
+            sh:select """
+    SELECT ?this WHERE {
+     ?this rdfs:subClassOf+ ref:ExternalReference .
+    }
+    """^^xsd:string ] .
+
+ref:HTTPHeaderShape a sh:NodeShape ;
+    skos:definition "Shape for validating HTTP headers."^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:httpHeaderName ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:httpHeaderValue ] ;
+    sh:targetClass ref:HTTPHeader .
+
+ref:HTTPQueryParameterShape a sh:NodeShape ;
+    skos:definition "Shape for validating HTTP query parameters."^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:httpParamName ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:httpParamValue ] ;
+    sh:targetClass ref:HTTPQueryParameter .
+
+ref:HTTPReferenceShape a sh:NodeShape ;
+    skos:definition "Infers an HTTPReference instance from the object of an hasExternalReference when httpBaseUrl is present."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition [ sh:property [ sh:minCount 1 ;
+                            sh:path ref:httpBaseUrl ] ] ;
+            sh:object ref:HTTPReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:HTTPTimeseriesReferenceShape a sh:NodeShape ;
+    skos:definition "Infers an HTTPTimeseriesReference instance from the object of an hasExternalReference when httpBaseUrl and hasTimeseriesId are present."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition [ sh:property [ sh:minCount 1 ;
+                            sh:path ref:httpBaseUrl ],
+                        [ sh:minCount 1 ;
+                            sh:path ref:hasTimeseriesId ] ] ;
+            sh:object ref:HTTPTimeseriesReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:IFCReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a IFCReference instance from the object of an hasExternalReference."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:IFCReference ;
+            sh:object ref:IFCReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:InfluxDBReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "InfluxDB Record Reference"^^xsd:string ;
+    rdfs:subClassOf ref:TimeseriesReference ;
+    skos:definition "Refers to an InfluxDB measurement within a bucket, stored on an InfluxDB server."^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:influxDBMeasurement ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:influxDBBucket ],
+        [ sh:class ref:InfluxDBServer ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:path ref:storedAt ] .
+
+ref:PreferredShape a sh:NodeShape ;
+    sh:property [ sh:message "An entity can only have one 'preferred' External Reference"^^xsd:string ;
+            sh:path ref:hasExternalReference ;
+            sh:qualifiedMaxCount 1 ;
+            sh:qualifiedValueShape [ sh:class ref:ExternalReference ;
+                    sh:property [ sh:datatype xsd:boolean ;
+                            sh:hasValue true ;
+                            sh:path ref:preferred ] ] ] ;
+    sh:targetSubjectsOf ref:hasExternalReference .
+
+ref:TimeseriesReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a TimeseriesReference instance from the object of an hasExternalReference."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:TimeseriesReference ;
+            sh:object ref:TimeseriesReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:bacnet-read-property a owl:DatatypeProperty ;
+    rdfs:label "bacnet-read-property"^^xsd:string ;
+    rdfs:comment "The property of the BACnet object to read to get the current value of this entity."^^xsd:string .
+
+ref:csvReferenceShape a sh:NodeShape ;
+    skos:definition "Infers a csvReference instance from the object of an hasExternalReference."^^xsd:string ;
+    sh:rule [ a sh:TripleRule ;
+            sh:condition ref:csvReference ;
+            sh:object ref:csvReference ;
+            sh:predicate rdf:type ;
+            sh:subject sh:this ] ;
+    sh:targetObjectsOf ref:hasExternalReference .
+
+ref:hasCsvReference a owl:ObjectProperty ;
+    rdfs:label "hasCsvReference"^^xsd:string ;
+    skos:definition "A reference to the CSV file that defines this entity"^^xsd:string .
+
+ref:hasHTTPReference a owl:ObjectProperty ;
+    rdfs:label "hasHTTPReference"^^xsd:string ;
+    rdfs:subPropertyOf ref:hasExternalReference ;
+    skos:definition "A reference to data accessible via an HTTP API endpoint."^^xsd:string .
+
+ref:hasHTTPTimeseriesReference a owl:ObjectProperty ;
+    rdfs:label "hasHTTPTimeseriesReference"^^xsd:string ;
+    rdfs:subPropertyOf ref:hasTimeseriesReference ;
+    skos:definition "A reference to timeseries data accessible via an HTTP API endpoint."^^xsd:string .
+
+bacnet:description a bacnet:StandardProperty,
+        owl:DatatypeProperty ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-description ;
+    bacnet:propertyName "description"^^xsd:string ;
+    bacnet:propertyRef bacnet:Description ;
+    skos:definition "The content of the description field of the BACnet object."^^xsd:string .
+
+bacnet:object-identifier a bacnet:StandardProperty,
+        rdf:Property,
+        owl:DatatypeProperty ;
+    rdfs:label "object-identifier"^^xsd:string ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-identifier ;
+    bacnet:propertyName "object-identifier"^^xsd:string ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Identifier ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The BACnet object identifier"^^xsd:string .
+
+bacnet:object-name a bacnet:StandardProperty,
+        owl:DatatypeProperty ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-name ;
+    bacnet:propertyName "object-name"^^xsd:string ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Name ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The content of the name field of the BACnet object."^^xsd:string .
+
+bacnet:object-type a bacnet:StandardProperty,
+        rdf:Property,
+        owl:DatatypeProperty ;
+    rdfs:label "object-type"^^xsd:string ;
+    bacnet:propertyEnum bacnet:PropertyIdentifier-object-type ;
+    bacnet:propertyName "object-type"^^xsd:string ;
+    bacnet:propertyOf bacnet:Object ;
+    bacnet:propertyRef bacnet:Object_Type ;
+    rdfs:subPropertyOf bacnet:ReadableProperty ;
+    skos:definition "The type of the BACnet object"^^xsd:string .
+
+bacnet:objectOf a owl:ObjectProperty ;
+    rdfs:label "objectOf"^^xsd:string ;
+    rdfs:comment "The 'parent' BACnet device that hosts this BACnet object."^^xsd:string ;
+    rdfs:range bacnet:BACnetDevice .
+
+<https://brickschema.org/schema/Brick/ref> a owl:Ontology ;
+    dcterms:creator ( [ a schemaorg:Person ;
+                schemaorg:email "gtfierro@mines.edu"^^xsd:string ;
+                schemaorg:name "Gabe Fierro"^^xsd:string ] ) ;
+    dcterms:title "Ref Schema"^^xsd:string ;
+    owl:versionInfo "git:HEAD@8af7aed29087cfe95bc3983c02b3f3e9bd684f2a date:2026-02-02T09:23:05-07:00" ;
+    sh:declare [ sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+            sh:prefix "sh"^^xsd:string ],
+        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+            sh:prefix "rdf"^^xsd:string ],
+        [ sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
+            sh:prefix "rdfs"^^xsd:string ],
+        [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+            sh:prefix "owl"^^xsd:string ],
+        [ sh:namespace "https://brickschema.org/schema/Brick/ref#"^^xsd:anyURI ;
+            sh:prefix "ref"^^xsd:string ] .
+
+ref:BACnetURI a owl:DatatypeProperty ;
+    rdfs:label "BACnetURI"^^xsd:string ;
+    rdfs:comment "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]"^^xsd:string .
+
+ref:HTTPTimeseriesReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "HTTP Timeseries Reference"^^xsd:string ;
+    rdfs:subClassOf ref:HTTPReference,
+        ref:TimeseriesReference ;
+    skos:definition "A reference to timeseries data accessible via an HTTP API endpoint."^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:path ref:httpResponsePath ] .
+
+ref:InfluxDBServer a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "InfluxDB Database Server Reference"^^xsd:string ;
+    rdfs:comment "A reference to an InfluxDB database server."^^xsd:string ;
+    skos:definition "Refers to an InfluxDB database server"^^xsd:string ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:influxDBUrl ],
+        [ sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:influxDBTokenLocation ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:influxDBOrg ],
+        [ sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:influxDBAuthenticationMethod ] .
+
+ref:csvColumnID a owl:DatatypeProperty ;
+    rdfs:label "The column name of the CSV reference as defined in the file"^^xsd:string ;
+    rdfs:range xsd:string .
+
+ref:csvFileLocation a owl:DatatypeProperty ;
+    rdfs:label "The Location of the CSV file"^^xsd:string ;
+    rdfs:range xsd:string .
+
+ref:hasHTTPHeader a owl:ObjectProperty ;
+    rdfs:label "has HTTP Header"^^xsd:string ;
+    rdfs:range ref:HTTPHeader ;
+    skos:definition "Links to an HTTP header key-value pair."^^xsd:string .
+
+ref:hasHTTPQueryParam a owl:ObjectProperty ;
+    rdfs:label "has HTTP Query Parameter"^^xsd:string ;
+    rdfs:range ref:HTTPQueryParameter ;
+    skos:definition "Links to an HTTP query parameter key-value pair."^^xsd:string .
+
+ref:hasIfcProjectReference a owl:ObjectProperty ;
+    rdfs:label "hasIfcProjectReference"^^xsd:string ;
+    skos:definition "A reference to the IFC Project that defines this entity"^^xsd:string .
+
+ref:hasTimeseriesReference a owl:ObjectProperty ;
+    rdfs:label "hasTimeseriesReference"^^xsd:string ;
+    rdfs:range ref:TimeseriesReference ;
+    rdfs:subPropertyOf ref:hasExternalReference ;
+    skos:definition "Metadata for accessing related timeseries data: Relates a data source (such as a Brick Point or 223 Property) to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
+
+ref:httpContentType a owl:DatatypeProperty ;
+    rdfs:label "HTTP Content Type"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "The expected content type of the response (e.g., application/json, text/csv)."^^xsd:string .
+
+ref:httpHeaderName a owl:DatatypeProperty ;
+    rdfs:label "HTTP Header Name"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "The name of an HTTP header."^^xsd:string .
+
+ref:httpHeaderValue a owl:DatatypeProperty ;
+    rdfs:label "HTTP Header Value"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "The value of an HTTP header. Use env: or $ prefix to reference environment variables. Never store secrets in plaintext."^^xsd:string .
+
+ref:httpMethod a owl:DatatypeProperty ;
+    rdfs:label "HTTP Method"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "The HTTP method to use for the request (GET, POST, PUT, DELETE, etc.). Defaults to GET if not specified."^^xsd:string .
+
+ref:httpParamName a owl:DatatypeProperty ;
+    rdfs:label "HTTP Parameter Name"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "The name (key) of an HTTP query parameter."^^xsd:string .
+
+ref:httpParamValue a owl:DatatypeProperty ;
+    rdfs:label "HTTP Parameter Value"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "The value of an HTTP query parameter. Use env: or $ prefix to reference environment variables."^^xsd:string .
+
+ref:httpResponsePath a owl:DatatypeProperty ;
+    rdfs:label "HTTP Response Path"^^xsd:string ;
+    rdfs:range xsd:string ;
+    skos:definition "A JSONPath or similar expression for extracting data from the HTTP response."^^xsd:string .
+
+ref:ifcFileLocation a owl:DatatypeProperty ;
+    rdfs:label "The location of the IFC file defining a project"^^xsd:string ;
+    rdfs:range xsd:string .
+
+ref:ifcGlobalID a owl:DatatypeProperty ;
+    rdfs:label "ifcGlobalID"^^xsd:string ;
+    skos:definition "The IFC Global ID of the entity"^^xsd:string .
+
+ref:ifcName a owl:DatatypeProperty ;
+    rdfs:label "ifcName"^^xsd:string ;
+    skos:definition "The name of the IFC entity"^^xsd:string .
+
+ref:ifcProject a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "IfcProject"^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:ifcProjectID ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:ifcFileLocation ] .
+
+ref:ifcProjectID a owl:DatatypeProperty ;
+    rdfs:label "ifcProjectID"^^xsd:string ;
+    skos:definition "The IFC ID of the containing project"^^xsd:string .
+
+ref:preferred a owl:DatatypeProperty ;
+    skos:definition "An entity can have one 'preferred' External Reference. Consumers of the model should prioritize any external reference with the 'preferred' property"^^xsd:string .
+
+ref:BACnetReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "BACnet Reference"^^xsd:string ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to the BACnet object represented by this entity."^^xsd:string ;
+    sh:or ( [ sh:property [ a sh:PropertyShape ;
+                        sh:class bacnet:EngineeringUnitsEnumerationValue ;
+                        sh:maxCount 1 ;
+                        sh:minCount 0 ;
+                        sh:path bacnet:units ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minCount 1 ;
+                        sh:path bacnet:object-identifier ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:object-type ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype bacnet:Property ;
+                        sh:defaultValue bacnet:Present_Value ;
+                        sh:path ref:read-property ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:path bacnet:description ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype xsd:string ;
+                        sh:minLength 1 ;
+                        sh:path bacnet:object-name ] ] [ sh:property [ a sh:PropertyShape ;
+                        skos:definition "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]"^^xsd:string ;
+                        sh:datatype xsd:string ;
+                        sh:path ref:BACnetURI ] ] ) ;
+    sh:property [ a sh:PropertyShape ;
+            sh:class bacnet:BACnetDevice ;
+            sh:minCount 1 ;
+            sh:path bacnet:objectOf ] .
+
+ref:HTTPReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "HTTP Reference"^^xsd:string ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to data accessible via an HTTP API endpoint."^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:in ( "GET"^^xsd:string "POST"^^xsd:string "PUT"^^xsd:string ) ;
+            sh:maxCount 1 ;
+            sh:path ref:httpMethod ],
+        [ sh:datatype xsd:anyURI ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:httpBaseUrl ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:path ref:httpContentType ],
+        [ sh:class ref:HTTPQueryParameter ;
+            sh:path ref:hasHTTPQueryParam ],
+        [ sh:class ref:HTTPHeader ;
+            sh:path ref:hasHTTPHeader ] .
+
+ref:IFCReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "Industry Foundation Classes Reference"^^xsd:string ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to an entity in an IFC project which may contain additional metadata about this entity."^^xsd:string ;
+    sh:property [ a sh:PropertyShape ;
+            skos:definition "Reference to an IFC Project object, containing the project ID"^^xsd:string ;
+            sh:class ref:ifcProject ;
+            sh:minCount 1 ;
+            sh:path ref:hasIfcProjectReference ],
+        [ a sh:PropertyShape ;
+            skos:definition "The global ID of the entity in the IFC project"^^xsd:string ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:ifcGlobalID ],
+        [ a sh:PropertyShape ;
+            skos:definition "Name of the entity in IFC"^^xsd:string ;
+            sh:datatype xsd:string ;
+            sh:path ref:ifcName ] .
+
+ref:csvReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "csvReference"^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:csvColumnID ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path ref:csvFileLocation ] .
+
+ref:hasTimeseriesId a owl:DatatypeProperty ;
+    rdfs:label "hasTimeseriesId"^^xsd:string ;
+    skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
+
+ref:storedAt a owl:DatatypeProperty ;
+    rdfs:label "storedAt"^^xsd:string ;
+    skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
+
+ref:HTTPHeader a owl:Class ;
+    rdfs:label "HTTP Header"^^xsd:string ;
+    skos:definition "A key-value pair representing an HTTP header."^^xsd:string .
+
+ref:HTTPQueryParameter a owl:Class ;
+    rdfs:label "HTTP Query Parameter"^^xsd:string ;
+    skos:definition "A key-value pair representing an HTTP query parameter."^^xsd:string .
+
+ref:httpBaseUrl a owl:DatatypeProperty ;
+    rdfs:label "HTTP Base URL"^^xsd:string ;
+    rdfs:range xsd:anyURI ;
+    skos:definition "The base URL of the HTTP API endpoint, excluding query parameters."^^xsd:string .
+
+ref:ExternalReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "External reference"^^xsd:string ;
+    rdfs:subClassOf <http://data.ashrae.org/standard223#ExternalReference> ;
+    skos:definition "The parent class of all external reference types"^^xsd:string .
+
+ref:TimeseriesReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "Timeseries Reference"^^xsd:string ;
+    rdfs:subClassOf ref:ExternalReference ;
+    skos:definition "A reference to a stream of timeseries data in a database. Contains the data for this entity"^^xsd:string ;
+    sh:property [ a sh:PropertyShape ;
+            skos:definition "Refers to a database storing the timeseries data for the related point. Properties on this class are *to be determined*; feel free to add arbitrary properties onto Database instances for your particular deployment"^^xsd:string ;
+            sh:nodeKind sh:IRIOrLiteral ;
+            sh:path ref:storedAt ],
+        [ a sh:PropertyShape ;
+            skos:definition "The identifier for the timeseries data corresponding to this point"^^xsd:string ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path ref:hasTimeseriesId ] .
+
+ref:hasExternalReference a owl:ObjectProperty ;
+    rdfs:label "hasExternalReference"^^xsd:string ;
+    rdfs:subPropertyOf <http://data.ashrae.org/standard223#hasExternalReference> ;
+    skos:definition "Points to the external reference for this entity, which contains additional metadata/data not included in this graph."^^xsd:string .
+

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -135,7 +135,6 @@ def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
     for key, label, _unit, _qk in _METRIC_DEFS:
         s = stream_uri(hostname, key)
         handle = compute_handle(src_id, key)
-        ref_node = URIRef(str(s) + "#ref")
 
         # Link host → stream
         g.add((h, S223.hasProperty, s))
@@ -147,12 +146,12 @@ def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
 
         # Brick-style external reference → Acquirium TimescaleDB
         # ref:hasTimeseriesId holds the globally-unique handle (actual DB key)
-        g.add((s,        HAS_EXTERNAL_REFERENCE, ref_node))
-        g.add((ref_node, RDF.type, TIMESERIES_REFERENCE))
-        g.add((ref_node, HAS_TIMESERIES_ID,      Literal(handle)))
-        g.add((ref_node, ACQUIRIUM_SOURCE_ID,               Literal(src_id)))
-        g.add((ref_node, ACQUIRIUM_REF_NAME,                Literal(key)))
-        g.add((ref_node, STORED_AT,               ACQUIRIUM_DB_URI))
+        g.add((s,        HAS_EXTERNAL_REFERENCE, handle))
+        g.add((handle, RDF.type, TIMESERIES_REFERENCE))
+        g.add((handle, HAS_TIMESERIES_ID,     handle))
+        g.add((handle, ACQUIRIUM_SOURCE_ID,               Literal(src_id)))
+        g.add((handle, ACQUIRIUM_REF_NAME,                Literal(key)))
+        g.add((handle, STORED_AT,               ACQUIRIUM_DB_URI))
 
     turtle = g.serialize(format="turtle")
     aq.client.insert_graph(turtle, format="turtle", replace=False)

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -236,7 +236,8 @@ def main() -> None:
     while True:
         ts = datetime.now(tz=timezone.utc)
         sample = collect()
-        result = aq.insert_timeseries_batch(src_id, sample)
+        streams = {rn: [(ts, value)] for rn, value in sample.items()}
+        result = aq.insert_timeseries_batch(src_id, streams)
         print(f"[{ts.isoformat()}] inserted {result.get('rows_inserted', '?')} rows")
         time.sleep(args.interval)
 

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -1,59 +1,189 @@
 """
 Continuously reads system metrics via psutil and publishes them to an Acquirium backend.
 
+On startup, inserts an RDF description of the host machine as an s223:Computer
+with s223:hasProperty links to each metric stream.  Each stream has an
+acquirium:hasExternalReference node pointing at the Acquirium TimescaleDB store.
+
 Usage:
-    uv run scripts/publish_system_metrics.py
-    uv run scripts/publish_system_metrics.py --url http://myserver --port 8000 --interval 5
+    uv run --with psutil scripts/publish_system_metrics.py
+    uv run --with psutil scripts/publish_system_metrics.py --url http://myserver --port 8000 --interval 5
 """
 
 import argparse
+import platform
+import socket
 import time
 from datetime import datetime, timezone
 
 import psutil
+from rdflib import Graph, Literal, URIRef, Namespace
+from rdflib.namespace import RDF, RDFS
 
 from acquirium import Acquirium
-from acquirium.internals.internals_namespaces import QUDT_QUANTITY_KIND, QUDT_UNIT
+from acquirium.internals.internals_namespaces import (
+    ACQUIRIUM_NS,
+    HAS_EXTERNAL_REFERENCE,
+    HAS_QUANTITY_KIND,
+    HAS_UNIT,
+    S223,
+    STREAM,
+    TIMESERIES_STREAM,
+    VIRTUAL_POINT,
+    QUDT_QUANTITY_KIND,
+    QUDT_UNIT,
+)
 
-# Metadata for each metric stream: uri → (label, unit, quantity_kind)
-METRICS: dict[str, tuple[str, str, str]] = {
-    "urn:system:cpu_percent":       ("CPU usage",              "%",    str(QUDT_QUANTITY_KIND.DimensionlessRatio)),
-    "urn:system:memory_percent":    ("RAM usage",              "%",    str(QUDT_QUANTITY_KIND.DimensionlessRatio)),
-    "urn:system:memory_used_bytes": ("RAM used",               "byte", str(QUDT_UNIT.BYTE)),
-    "urn:system:disk_percent":      ("Disk usage (root)",      "%",    str(QUDT_QUANTITY_KIND.DimensionlessRatio)),
-    "urn:system:net_bytes_sent":    ("Network bytes sent",     "byte", str(QUDT_UNIT.BYTE)),
-    "urn:system:net_bytes_recv":    ("Network bytes received", "byte", str(QUDT_UNIT.BYTE)),
-}
+# Custom namespace for host-level properties not covered by S223 or QUDT.
+HOST_NS = Namespace("urn:acquirium:host#")
+
+# Metric definitions: short key → (label, unit hint, quantity_kind hint)
+# URIs are constructed at runtime using the host's name so multiple hosts
+# can publish to the same Acquirium instance without URI collisions.
+_METRIC_DEFS: list[tuple[str, str, str, str]] = [
+    # (key,              label,                    unit,   quantity_kind)
+    ("cpu_percent",       "CPU usage",              "%",    "dimensionless ratio"),
+    ("memory_percent",    "RAM usage",              "%",    "dimensionless ratio"),
+    ("memory_used_bytes", "RAM used",               "byte", "data size"),
+    ("disk_percent",      "Disk usage (root)",      "%",    "dimensionless ratio"),
+    ("net_bytes_sent",    "Network bytes sent",     "byte", "data size"),
+    ("net_bytes_recv",    "Network bytes received", "byte", "data size"),
+]
 
 
-def collect() -> dict[str, float]:
-    """Collect one sample of each metric and return as {uri: value}."""
+# ---------------------------------------------------------------------------
+# URI helpers
+# ---------------------------------------------------------------------------
+
+def host_uri(hostname: str) -> URIRef:
+    return URIRef(f"urn:host:{hostname}")
+
+def stream_uri(hostname: str, key: str) -> URIRef:
+    return URIRef(f"urn:host:{hostname}:{key}")
+
+def ref_uri(hostname: str, key: str) -> URIRef:
+    """External reference node — identifies the acquirium TimescaleDB stream."""
+    return URIRef(f"urn:host:{hostname}:{key}:acquirium-ref")
+
+
+# ---------------------------------------------------------------------------
+# Host metadata
+# ---------------------------------------------------------------------------
+
+def get_host_info() -> dict:
+    hostname = socket.gethostname()
+    try:
+        ip = socket.gethostbyname(hostname)
+    except OSError:
+        ip = "127.0.0.1"
+    return {
+        "hostname": hostname,
+        "ip":       ip,
+        "os":       platform.system(),
+        "release":  platform.release(),
+        "platform": platform.platform(),
+        "machine":  platform.machine(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Graph registration
+# ---------------------------------------------------------------------------
+
+def register_host_graph(aq: Acquirium, host: dict) -> None:
+    """Insert a one-time RDF description of the host and its metric streams.
+
+    Graph shape (per host)::
+
+        <urn:host:{hostname}>
+            a s223:Computer ;
+            rdfs:label "{hostname}" ;
+            host:hasHostname "{hostname}" ;
+            host:hasIPAddress "{ip}" ;
+            host:hasOperatingSystem "{os} {release}" ;
+            host:hasPlatform "{platform}" ;
+            host:hasMachine "{machine}" ;
+            s223:hasProperty <urn:host:{hostname}:cpu_percent> ;
+            s223:hasProperty <urn:host:{hostname}:memory_percent> ;
+            ... .
+
+        <urn:host:{hostname}:cpu_percent>
+            a s223:Property, acquirium:VirtualPoint ;
+            rdfs:label "CPU usage" ;
+            acquirium:hasExternalReference <urn:host:{hostname}:cpu_percent:acquirium-ref> .
+
+        <urn:host:{hostname}:cpu_percent:acquirium-ref>
+            a acquirium:Stream, acquirium:TimeseriesStream ;
+            acquirium:storageBackend "timescale" .
+    """
+    hostname = host["hostname"]
+    g = Graph()
+    h = host_uri(hostname)
+
+    # Host node
+    g.add((h, RDF.type,               S223.Computer))
+    g.add((h, RDFS.label,             Literal(hostname)))
+    g.add((h, HOST_NS.hasHostname,    Literal(host["hostname"])))
+    g.add((h, HOST_NS.hasIPAddress,   Literal(host["ip"])))
+    g.add((h, HOST_NS.hasOperatingSystem, Literal(f"{host['os']} {host['release']}")))
+    g.add((h, HOST_NS.hasPlatform,    Literal(host["platform"])))
+    g.add((h, HOST_NS.hasMachine,     Literal(host["machine"])))
+
+    for key, label, _unit, _qk in _METRIC_DEFS:
+        s = stream_uri(hostname, key)
+        r = ref_uri(hostname, key)
+
+        # Link host → stream
+        g.add((h, S223.hasProperty, s))
+
+        # Stream node — typed as both s223:Property and acquirium:VirtualPoint
+        g.add((s, RDF.type,  S223.Property))
+        g.add((s, RDF.type,  VIRTUAL_POINT))
+        g.add((s, RDFS.label, Literal(label)))
+
+        # External reference → acquirium TimescaleDB
+        g.add((s, HAS_EXTERNAL_REFERENCE, r))
+        g.add((r, RDF.type,  STREAM))
+        g.add((r, RDF.type,  TIMESERIES_STREAM))
+        g.add((r, ACQUIRIUM_NS.storageBackend, Literal("timescale")))
+
+    turtle = g.serialize(format="turtle")
+    aq.client.insert_graph(turtle, format="turtle", replace=False)
+
+
+def register_stream_metadata(aq: Acquirium, hostname: str) -> None:
+    """Resolve and attach QUDT unit/quantity-kind metadata to each stream."""
+    for key, label, unit, quantity_kind in _METRIC_DEFS:
+        uri = stream_uri(hostname, key)
+        aq.register_stream(
+            uri,
+            unit=unit,
+            quantity_kind=quantity_kind,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data collection
+# ---------------------------------------------------------------------------
+
+def collect(hostname: str) -> dict[str, float]:
+    """Collect one sample of each metric, keyed by host-scoped stream URI."""
     mem  = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
     net  = psutil.net_io_counters()
     return {
-        "urn:system:cpu_percent":       psutil.cpu_percent(interval=None),
-        "urn:system:memory_percent":    mem.percent,
-        "urn:system:memory_used_bytes": mem.used,
-        "urn:system:disk_percent":      disk.percent,
-        "urn:system:net_bytes_sent":    net.bytes_sent,
-        "urn:system:net_bytes_recv":    net.bytes_recv,
+        str(stream_uri(hostname, "cpu_percent")):       psutil.cpu_percent(interval=None),
+        str(stream_uri(hostname, "memory_percent")):    mem.percent,
+        str(stream_uri(hostname, "memory_used_bytes")): mem.used,
+        str(stream_uri(hostname, "disk_percent")):      disk.percent,
+        str(stream_uri(hostname, "net_bytes_sent")):    net.bytes_sent,
+        str(stream_uri(hostname, "net_bytes_recv")):    net.bytes_recv,
     }
 
 
-def register_streams(aq: Acquirium) -> None:
-    """Declare each metric stream in the knowledge graph (idempotent)."""
-    print("Registering streams in graph...")
-    for uri, (label, unit, quantity_kind) in METRICS.items():
-        aq.register_stream(
-            uri,
-            label=label,
-            unit=unit,
-            quantity_kind=quantity_kind,
-        )
-        print(f"  registered {uri}")
-    print()
-
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Publish system metrics to Acquirium")
@@ -64,20 +194,29 @@ def main() -> None:
 
     aq = Acquirium(server_url=args.url, server_port=args.port)
 
-    register_streams(aq)
+    host = get_host_info()
+    hostname = host["hostname"]
+    print(f"Host: {hostname} ({host['ip']})  {host['platform']}")
 
-    print(f"Publishing to {args.url}:{args.port} every {args.interval}s")
+    print("Registering host graph...")
+    register_host_graph(aq, host)
+
+    print("Resolving and attaching QUDT metadata...")
+    register_stream_metadata(aq, hostname)
+
+    print(f"\nPublishing to {args.url}:{args.port} every {args.interval}s")
+    for key, label, _, _ in _METRIC_DEFS:
+        print(f"  {stream_uri(hostname, key)}  ({label})")
+    print()
 
     # Warm up cpu_percent (first call always returns 0.0)
     psutil.cpu_percent(interval=None)
 
     while True:
         ts = datetime.now(tz=timezone.utc)
-        sample = collect()
-
+        sample = collect(hostname)
         streams = {uri: [(ts, value)] for uri, value in sample.items()}
         result = aq.insert_timeseries_batch(streams)
-
         print(f"[{ts.isoformat()}] inserted {result.get('rows_inserted', '?')} rows")
         time.sleep(args.interval)
 

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -62,14 +62,18 @@ def stream_uri(hostname: str, key: str) -> URIRef:
     return URIRef(f"urn:host:{hostname}:{key}")
 
 def ref_uri(hostname: str, key: str) -> URIRef:
-    """External reference node for the acquirium TimescaleDB stream.
+    """URI of the external reference node for this stream.
 
-    For direct HTTP push the ref URI is the same as the stream URI — the
-    stream is its own external reference and data is stored under this key
-    in TimescaleDB.  This keeps the graph's hasExternalReference triple
-    consistent with what insert_timeseries_batch uses as the storage key.
+    This URI serves double duty:
+      - In the RDF graph it is the object of acquirium:hasExternalReference
+        on the point_uri, typed as acquirium:TimeseriesStream.
+      - In TimescaleDB it is the storage key under which data rows are kept.
+
+    Keeping it distinct from stream_uri (the point_uri) allows the semantic
+    identity of the measurement to remain stable even if the backing store
+    or ingestion path changes.
     """
-    return stream_uri(hostname, key)
+    return URIRef(f"urn:host:{hostname}:{key}:acquirium-ref")
 
 
 # ---------------------------------------------------------------------------
@@ -173,17 +177,22 @@ def register_stream_metadata(aq: Acquirium, hostname: str) -> None:
 # ---------------------------------------------------------------------------
 
 def collect(hostname: str) -> dict[str, float]:
-    """Collect one sample of each metric, keyed by host-scoped stream URI."""
+    """Collect one sample of each metric, keyed by ref_uri.
+
+    Data is stored in TimescaleDB under the ref_uri (not the point_uri).
+    The graph's hasExternalReference triple links point_uri → ref_uri,
+    so the query layer can join them at read time.
+    """
     mem  = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
     net  = psutil.net_io_counters()
     return {
-        str(stream_uri(hostname, "cpu_percent")):       psutil.cpu_percent(interval=None),
-        str(stream_uri(hostname, "memory_percent")):    mem.percent,
-        str(stream_uri(hostname, "memory_used_bytes")): mem.used,
-        str(stream_uri(hostname, "disk_percent")):      disk.percent,
-        str(stream_uri(hostname, "net_bytes_sent")):    net.bytes_sent,
-        str(stream_uri(hostname, "net_bytes_recv")):    net.bytes_recv,
+        str(ref_uri(hostname, "cpu_percent")):       psutil.cpu_percent(interval=None),
+        str(ref_uri(hostname, "memory_percent")):    mem.percent,
+        str(ref_uri(hostname, "memory_used_bytes")): mem.used,
+        str(ref_uri(hostname, "disk_percent")):      disk.percent,
+        str(ref_uri(hostname, "net_bytes_sent")):    net.bytes_sent,
+        str(ref_uri(hostname, "net_bytes_recv")):    net.bytes_recv,
     }
 
 

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -23,7 +23,8 @@ from rdflib.namespace import RDF, RDFS
 from acquirium import Acquirium
 from acquirium.internals.internals_namespaces import (
     ACQUIRIUM_DB_URI,
-    BRICK_REF,
+    ACQUIRIUM_REF_NAME,
+    ACQUIRIUM_SOURCE_ID,
     BRICK_REF_DATABASE,
     BRICK_REF_HAS_EXTERNAL_REFERENCE,
     BRICK_REF_HAS_TIMESERIES_ID,
@@ -34,6 +35,7 @@ from acquirium.internals.internals_namespaces import (
     QUDT_QUANTITY_KIND,
     QUDT_UNIT,
 )
+from acquirium.internals.models import compute_handle
 
 # Custom namespace for host-level properties not covered by S223 or QUDT.
 HOST_NS = Namespace("urn:acquirium:host#")
@@ -62,14 +64,14 @@ def host_uri(hostname: str) -> URIRef:
 def stream_uri(hostname: str, key: str) -> URIRef:
     return URIRef(f"urn:host:{hostname}:{key}")
 
-def ref_name(hostname: str, key: str) -> str:
-    """Source-native identifier for a metric stream.
+def source_id(hostname: str) -> str:
+    """Datasource identifier for this host's metrics publisher."""
+    return f"{hostname}-system-metrics"
 
-    This is the string stored as ``ref:hasTimeseriesId`` in the graph and
-    used as the TimescaleDB storage key.  It is host-scoped so multiple
-    machines can publish to the same Acquirium instance without collisions.
-    """
-    return f"{hostname}:{key}"
+
+def ref_name(key: str) -> str:
+    """Source-local stream identifier — just the metric key."""
+    return key
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +98,7 @@ def get_host_info() -> dict:
 # Graph registration
 # ---------------------------------------------------------------------------
 
-def register_host_graph(aq: Acquirium, host: dict) -> None:
+def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
     """Insert a one-time RDF description of the host and its metric streams.
 
     Graph shape (per host)::
@@ -139,7 +141,8 @@ def register_host_graph(aq: Acquirium, host: dict) -> None:
 
     for key, label, _unit, _qk in _METRIC_DEFS:
         s = stream_uri(hostname, key)
-        rn = ref_name(hostname, key)
+        rn = ref_name(key)
+        handle = compute_handle(src_id, rn)
         ref_node = URIRef(str(s) + "#ref")
 
         # Link host → stream
@@ -151,23 +154,27 @@ def register_host_graph(aq: Acquirium, host: dict) -> None:
         g.add((s, RDFS.label, Literal(label)))
 
         # Brick-style external reference → Acquirium TimescaleDB
+        # ref:hasTimeseriesId holds the globally-unique handle (actual DB key)
         g.add((s,        BRICK_REF_HAS_EXTERNAL_REFERENCE, ref_node))
         g.add((ref_node, RDF.type,                         BRICK_REF_TIMESERIES_REFERENCE))
-        g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(rn)))
-        g.add((ref_node, BRICK_REF_STORED_AT,              ACQUIRIUM_DB_URI))
+        g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(handle)))
+        g.add((ref_node, ACQUIRIUM_SOURCE_ID,               Literal(src_id)))
+        g.add((ref_node, ACQUIRIUM_REF_NAME,                Literal(rn)))
+        g.add((ref_node, BRICK_REF_STORED_AT,               ACQUIRIUM_DB_URI))
 
     turtle = g.serialize(format="turtle")
     aq.client.insert_graph(turtle, format="turtle", replace=False)
 
 
-def register_stream_metadata(aq: Acquirium, hostname: str) -> None:
+def register_stream_metadata(aq: Acquirium, hostname: str, src_id: str) -> None:
     """Resolve and attach QUDT unit/quantity-kind metadata to each stream."""
     for key, label, unit, quantity_kind in _METRIC_DEFS:
         aq.register_stream(
             stream_uri(hostname, key),
             unit=unit,
             quantity_kind=quantity_kind,
-            ref_name=ref_name(hostname, key),
+            source_id=src_id,
+            ref_name=ref_name(key),
         )
 
 
@@ -175,22 +182,18 @@ def register_stream_metadata(aq: Acquirium, hostname: str) -> None:
 # Data collection
 # ---------------------------------------------------------------------------
 
-def collect(hostname: str) -> dict[str, float]:
-    """Collect one sample of each metric, keyed by ref_name.
-
-    Data is stored in TimescaleDB under the ref_name (the source-native
-    identifier stored as ref:hasTimeseriesId in the graph).
-    """
+def collect() -> dict[str, float]:
+    """Collect one sample of each metric, keyed by ref_name."""
     mem  = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
     net  = psutil.net_io_counters()
     return {
-        ref_name(hostname, "cpu_percent"):       psutil.cpu_percent(interval=None),
-        ref_name(hostname, "memory_percent"):    mem.percent,
-        ref_name(hostname, "memory_used_bytes"): mem.used,
-        ref_name(hostname, "disk_percent"):      disk.percent,
-        ref_name(hostname, "net_bytes_sent"):    net.bytes_sent,
-        ref_name(hostname, "net_bytes_recv"):    net.bytes_recv,
+        ref_name("cpu_percent"):       psutil.cpu_percent(interval=None),
+        ref_name("memory_percent"):    mem.percent,
+        ref_name("memory_used_bytes"): mem.used,
+        ref_name("disk_percent"):      disk.percent,
+        ref_name("net_bytes_sent"):    net.bytes_sent,
+        ref_name("net_bytes_recv"):    net.bytes_recv,
     }
 
 
@@ -209,17 +212,22 @@ def main() -> None:
 
     host = get_host_info()
     hostname = host["hostname"]
+    src_id = source_id(hostname)
     print(f"Host: {hostname} ({host['ip']})  {host['platform']}")
+    print(f"Source ID: {src_id}")
+
+    print("Registering datasource...")
+    aq.register_datasource(src_id)
 
     print("Registering host graph...")
-    register_host_graph(aq, host)
+    register_host_graph(aq, host, src_id)
 
     print("Resolving and attaching QUDT metadata...")
-    register_stream_metadata(aq, hostname)
+    register_stream_metadata(aq, hostname, src_id)
 
     print(f"\nPublishing to {args.url}:{args.port} every {args.interval}s")
     for key, label, _, _ in _METRIC_DEFS:
-        print(f"  {stream_uri(hostname, key)}  ({label})")
+        print(f"  {stream_uri(hostname, key)}  ({label})  [{ref_name(key)}]")
     print()
 
     # Warm up cpu_percent (first call always returns 0.0)
@@ -227,9 +235,8 @@ def main() -> None:
 
     while True:
         ts = datetime.now(tz=timezone.utc)
-        sample = collect(hostname)
-        streams = {uri: [(ts, value)] for uri, value in sample.items()}
-        result = aq.insert_timeseries_batch(streams)
+        sample = collect()
+        result = aq.insert_timeseries_batch(src_id, sample)
         print(f"[{ts.isoformat()}] inserted {result.get('rows_inserted', '?')} rows")
         time.sleep(args.interval)
 

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -145,10 +145,9 @@ def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
         g.add((s, RDFS.label, Literal(label)))
 
         # Brick-style external reference → Acquirium TimescaleDB
-        # ref:hasTimeseriesId holds the globally-unique handle (actual DB key)
+        # the external reference node holds the globally-unique handle (actual DB key)
         g.add((s,        HAS_EXTERNAL_REFERENCE, handle))
         g.add((handle, RDF.type, TIMESERIES_REFERENCE))
-        g.add((handle, HAS_TIMESERIES_ID,     handle))
         g.add((handle, ACQUIRIUM_SOURCE_ID,               Literal(src_id)))
         g.add((handle, ACQUIRIUM_REF_NAME,                Literal(key)))
         g.add((handle, STORED_AT,               ACQUIRIUM_DB_URI))

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -32,8 +32,6 @@ from acquirium.internals.internals_namespaces import (
     BRICK_REF_TIMESERIES_REFERENCE,
     S223,
     VIRTUAL_POINT,
-    QUDT_QUANTITY_KIND,
-    QUDT_UNIT,
 )
 from acquirium.internals.models import compute_handle
 
@@ -67,11 +65,6 @@ def stream_uri(hostname: str, key: str) -> URIRef:
 def source_id(hostname: str) -> str:
     """Datasource identifier for this host's metrics publisher."""
     return f"{hostname}-system-metrics"
-
-
-def ref_name(key: str) -> str:
-    """Source-local stream identifier — just the metric key."""
-    return key
 
 
 # ---------------------------------------------------------------------------
@@ -141,8 +134,7 @@ def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
 
     for key, label, _unit, _qk in _METRIC_DEFS:
         s = stream_uri(hostname, key)
-        rn = ref_name(key)
-        handle = compute_handle(src_id, rn)
+        handle = compute_handle(src_id, key)
         ref_node = URIRef(str(s) + "#ref")
 
         # Link host → stream
@@ -159,7 +151,7 @@ def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
         g.add((ref_node, RDF.type,                         BRICK_REF_TIMESERIES_REFERENCE))
         g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(handle)))
         g.add((ref_node, ACQUIRIUM_SOURCE_ID,               Literal(src_id)))
-        g.add((ref_node, ACQUIRIUM_REF_NAME,                Literal(rn)))
+        g.add((ref_node, ACQUIRIUM_REF_NAME,                Literal(key)))
         g.add((ref_node, BRICK_REF_STORED_AT,               ACQUIRIUM_DB_URI))
 
     turtle = g.serialize(format="turtle")
@@ -174,7 +166,7 @@ def register_stream_metadata(aq: Acquirium, hostname: str, src_id: str) -> None:
             unit=unit,
             quantity_kind=quantity_kind,
             source_id=src_id,
-            ref_name=ref_name(key),
+            ref_name=key,
         )
 
 
@@ -188,12 +180,12 @@ def collect() -> dict[str, float]:
     disk = psutil.disk_usage("/")
     net  = psutil.net_io_counters()
     return {
-        ref_name("cpu_percent"):       psutil.cpu_percent(interval=None),
-        ref_name("memory_percent"):    mem.percent,
-        ref_name("memory_used_bytes"): mem.used,
-        ref_name("disk_percent"):      disk.percent,
-        ref_name("net_bytes_sent"):    net.bytes_sent,
-        ref_name("net_bytes_recv"):    net.bytes_recv,
+        "cpu_percent":       psutil.cpu_percent(interval=None),
+        "memory_percent":    mem.percent,
+        "memory_used_bytes": mem.used,
+        "disk_percent":      disk.percent,
+        "net_bytes_sent":    net.bytes_sent,
+        "net_bytes_recv":    net.bytes_recv,
     }
 
 
@@ -227,7 +219,7 @@ def main() -> None:
 
     print(f"\nPublishing to {args.url}:{args.port} every {args.interval}s")
     for key, label, _, _ in _METRIC_DEFS:
-        print(f"  {stream_uri(hostname, key)}  ({label})  [{ref_name(key)}]")
+        print(f"  {stream_uri(hostname, key)}  ({label})  [{key}]")
     print()
 
     # Warm up cpu_percent (first call always returns 0.0)

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -22,13 +22,14 @@ from rdflib.namespace import RDF, RDFS
 
 from acquirium import Acquirium
 from acquirium.internals.internals_namespaces import (
-    ACQUIRIUM_NS,
-    HAS_EXTERNAL_REFERENCE,
-    HAS_QUANTITY_KIND,
-    HAS_UNIT,
+    ACQUIRIUM_DB_URI,
+    BRICK_REF,
+    BRICK_REF_DATABASE,
+    BRICK_REF_HAS_EXTERNAL_REFERENCE,
+    BRICK_REF_HAS_TIMESERIES_ID,
+    BRICK_REF_STORED_AT,
+    BRICK_REF_TIMESERIES_REFERENCE,
     S223,
-    STREAM,
-    TIMESERIES_STREAM,
     VIRTUAL_POINT,
     QUDT_QUANTITY_KIND,
     QUDT_UNIT,
@@ -61,19 +62,14 @@ def host_uri(hostname: str) -> URIRef:
 def stream_uri(hostname: str, key: str) -> URIRef:
     return URIRef(f"urn:host:{hostname}:{key}")
 
-def ref_uri(hostname: str, key: str) -> URIRef:
-    """URI of the external reference node for this stream.
+def ref_name(hostname: str, key: str) -> str:
+    """Source-native identifier for a metric stream.
 
-    This URI serves double duty:
-      - In the RDF graph it is the object of acquirium:hasExternalReference
-        on the point_uri, typed as acquirium:TimeseriesStream.
-      - In TimescaleDB it is the storage key under which data rows are kept.
-
-    Keeping it distinct from stream_uri (the point_uri) allows the semantic
-    identity of the measurement to remain stable even if the backing store
-    or ingestion path changes.
+    This is the string stored as ``ref:hasTimeseriesId`` in the graph and
+    used as the TimescaleDB storage key.  It is host-scoped so multiple
+    machines can publish to the same Acquirium instance without collisions.
     """
-    return URIRef(f"urn:host:{hostname}:{key}:acquirium-ref")
+    return f"{hostname}:{key}"
 
 
 # ---------------------------------------------------------------------------
@@ -108,54 +104,57 @@ def register_host_graph(aq: Acquirium, host: dict) -> None:
         <urn:host:{hostname}>
             a s223:Computer ;
             rdfs:label "{hostname}" ;
-            host:hasHostname "{hostname}" ;
-            host:hasIPAddress "{ip}" ;
-            host:hasOperatingSystem "{os} {release}" ;
-            host:hasPlatform "{platform}" ;
-            host:hasMachine "{machine}" ;
+            host:hasHostname, host:hasIPAddress, ... ;
             s223:hasProperty <urn:host:{hostname}:cpu_percent> ;
-            s223:hasProperty <urn:host:{hostname}:memory_percent> ;
             ... .
 
         <urn:host:{hostname}:cpu_percent>
             a s223:Property, acquirium:VirtualPoint ;
             rdfs:label "CPU usage" ;
-            acquirium:hasExternalReference <urn:host:{hostname}:cpu_percent:acquirium-ref> .
+            ref:hasExternalReference <urn:host:{hostname}:cpu_percent#ref> .
 
-        <urn:host:{hostname}:cpu_percent:acquirium-ref>
-            a acquirium:Stream, acquirium:TimeseriesStream ;
-            acquirium:storageBackend "timescale" .
+        <urn:host:{hostname}:cpu_percent#ref>
+            a ref:TimeseriesReference ;
+            ref:hasTimeseriesId "{hostname}:cpu_percent" ;
+            ref:storedAt <urn:acquirium:timescaledb> .
+
+        <urn:acquirium:timescaledb>  a  ref:Database .
     """
     hostname = host["hostname"]
     g = Graph()
     h = host_uri(hostname)
 
+    # Declare the Acquirium DB node once per graph (idempotent across calls)
+    g.add((ACQUIRIUM_DB_URI, RDF.type,   BRICK_REF_DATABASE))
+    g.add((ACQUIRIUM_DB_URI, RDFS.label, Literal("Acquirium TimescaleDB")))
+
     # Host node
-    g.add((h, RDF.type,               S223.Computer))
-    g.add((h, RDFS.label,             Literal(hostname)))
-    g.add((h, HOST_NS.hasHostname,    Literal(host["hostname"])))
-    g.add((h, HOST_NS.hasIPAddress,   Literal(host["ip"])))
+    g.add((h, RDF.type,                   S223.Computer))
+    g.add((h, RDFS.label,                 Literal(hostname)))
+    g.add((h, HOST_NS.hasHostname,        Literal(host["hostname"])))
+    g.add((h, HOST_NS.hasIPAddress,       Literal(host["ip"])))
     g.add((h, HOST_NS.hasOperatingSystem, Literal(f"{host['os']} {host['release']}")))
-    g.add((h, HOST_NS.hasPlatform,    Literal(host["platform"])))
-    g.add((h, HOST_NS.hasMachine,     Literal(host["machine"])))
+    g.add((h, HOST_NS.hasPlatform,        Literal(host["platform"])))
+    g.add((h, HOST_NS.hasMachine,         Literal(host["machine"])))
 
     for key, label, _unit, _qk in _METRIC_DEFS:
         s = stream_uri(hostname, key)
-        r = ref_uri(hostname, key)
+        rn = ref_name(hostname, key)
+        ref_node = URIRef(str(s) + "#ref")
 
         # Link host → stream
         g.add((h, S223.hasProperty, s))
 
-        # Stream node — typed as both s223:Property and acquirium:VirtualPoint
-        g.add((s, RDF.type,  S223.Property))
-        g.add((s, RDF.type,  VIRTUAL_POINT))
+        # Stream node
+        g.add((s, RDF.type,   S223.Property))
+        g.add((s, RDF.type,   VIRTUAL_POINT))
         g.add((s, RDFS.label, Literal(label)))
 
-        # External reference → acquirium TimescaleDB
-        g.add((s, HAS_EXTERNAL_REFERENCE, r))
-        g.add((r, RDF.type,  STREAM))
-        g.add((r, RDF.type,  TIMESERIES_STREAM))
-        g.add((r, ACQUIRIUM_NS.storageBackend, Literal("timescale")))
+        # Brick-style external reference → Acquirium TimescaleDB
+        g.add((s,        BRICK_REF_HAS_EXTERNAL_REFERENCE, ref_node))
+        g.add((ref_node, RDF.type,                         BRICK_REF_TIMESERIES_REFERENCE))
+        g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(rn)))
+        g.add((ref_node, BRICK_REF_STORED_AT,              ACQUIRIUM_DB_URI))
 
     turtle = g.serialize(format="turtle")
     aq.client.insert_graph(turtle, format="turtle", replace=False)
@@ -164,11 +163,11 @@ def register_host_graph(aq: Acquirium, host: dict) -> None:
 def register_stream_metadata(aq: Acquirium, hostname: str) -> None:
     """Resolve and attach QUDT unit/quantity-kind metadata to each stream."""
     for key, label, unit, quantity_kind in _METRIC_DEFS:
-        uri = stream_uri(hostname, key)
         aq.register_stream(
-            uri,
+            stream_uri(hostname, key),
             unit=unit,
             quantity_kind=quantity_kind,
+            ref_name=ref_name(hostname, key),
         )
 
 
@@ -177,22 +176,21 @@ def register_stream_metadata(aq: Acquirium, hostname: str) -> None:
 # ---------------------------------------------------------------------------
 
 def collect(hostname: str) -> dict[str, float]:
-    """Collect one sample of each metric, keyed by ref_uri.
+    """Collect one sample of each metric, keyed by ref_name.
 
-    Data is stored in TimescaleDB under the ref_uri (not the point_uri).
-    The graph's hasExternalReference triple links point_uri → ref_uri,
-    so the query layer can join them at read time.
+    Data is stored in TimescaleDB under the ref_name (the source-native
+    identifier stored as ref:hasTimeseriesId in the graph).
     """
     mem  = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
     net  = psutil.net_io_counters()
     return {
-        str(ref_uri(hostname, "cpu_percent")):       psutil.cpu_percent(interval=None),
-        str(ref_uri(hostname, "memory_percent")):    mem.percent,
-        str(ref_uri(hostname, "memory_used_bytes")): mem.used,
-        str(ref_uri(hostname, "disk_percent")):      disk.percent,
-        str(ref_uri(hostname, "net_bytes_sent")):    net.bytes_sent,
-        str(ref_uri(hostname, "net_bytes_recv")):    net.bytes_recv,
+        ref_name(hostname, "cpu_percent"):       psutil.cpu_percent(interval=None),
+        ref_name(hostname, "memory_percent"):    mem.percent,
+        ref_name(hostname, "memory_used_bytes"): mem.used,
+        ref_name(hostname, "disk_percent"):      disk.percent,
+        ref_name(hostname, "net_bytes_sent"):    net.bytes_sent,
+        ref_name(hostname, "net_bytes_recv"):    net.bytes_recv,
     }
 
 

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -62,8 +62,14 @@ def stream_uri(hostname: str, key: str) -> URIRef:
     return URIRef(f"urn:host:{hostname}:{key}")
 
 def ref_uri(hostname: str, key: str) -> URIRef:
-    """External reference node — identifies the acquirium TimescaleDB stream."""
-    return URIRef(f"urn:host:{hostname}:{key}:acquirium-ref")
+    """External reference node for the acquirium TimescaleDB stream.
+
+    For direct HTTP push the ref URI is the same as the stream URI — the
+    stream is its own external reference and data is stored under this key
+    in TimescaleDB.  This keeps the graph's hasExternalReference triple
+    consistent with what insert_timeseries_batch uses as the storage key.
+    """
+    return stream_uri(hostname, key)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -1,0 +1,86 @@
+"""
+Continuously reads system metrics via psutil and publishes them to an Acquirium backend.
+
+Usage:
+    uv run scripts/publish_system_metrics.py
+    uv run scripts/publish_system_metrics.py --url http://myserver --port 8000 --interval 5
+"""
+
+import argparse
+import time
+from datetime import datetime, timezone
+
+import psutil
+
+from acquirium import Acquirium
+from acquirium.internals.internals_namespaces import QUDT_QUANTITY_KIND, QUDT_UNIT
+
+# Metadata for each metric stream: uri → (label, unit, quantity_kind)
+METRICS: dict[str, tuple[str, str, str]] = {
+    "urn:system:cpu_percent":       ("CPU usage",              "%",    str(QUDT_QUANTITY_KIND.DimensionlessRatio)),
+    "urn:system:memory_percent":    ("RAM usage",              "%",    str(QUDT_QUANTITY_KIND.DimensionlessRatio)),
+    "urn:system:memory_used_bytes": ("RAM used",               "byte", str(QUDT_UNIT.BYTE)),
+    "urn:system:disk_percent":      ("Disk usage (root)",      "%",    str(QUDT_QUANTITY_KIND.DimensionlessRatio)),
+    "urn:system:net_bytes_sent":    ("Network bytes sent",     "byte", str(QUDT_UNIT.BYTE)),
+    "urn:system:net_bytes_recv":    ("Network bytes received", "byte", str(QUDT_UNIT.BYTE)),
+}
+
+
+def collect() -> dict[str, float]:
+    """Collect one sample of each metric and return as {uri: value}."""
+    mem  = psutil.virtual_memory()
+    disk = psutil.disk_usage("/")
+    net  = psutil.net_io_counters()
+    return {
+        "urn:system:cpu_percent":       psutil.cpu_percent(interval=None),
+        "urn:system:memory_percent":    mem.percent,
+        "urn:system:memory_used_bytes": mem.used,
+        "urn:system:disk_percent":      disk.percent,
+        "urn:system:net_bytes_sent":    net.bytes_sent,
+        "urn:system:net_bytes_recv":    net.bytes_recv,
+    }
+
+
+def register_streams(aq: Acquirium) -> None:
+    """Declare each metric stream in the knowledge graph (idempotent)."""
+    print("Registering streams in graph...")
+    for uri, (label, unit, quantity_kind) in METRICS.items():
+        aq.register_stream(
+            uri,
+            label=label,
+            unit=unit,
+            quantity_kind=quantity_kind,
+        )
+        print(f"  registered {uri}")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish system metrics to Acquirium")
+    parser.add_argument("--url",      default="localhost", help="Acquirium server host")
+    parser.add_argument("--port",     default=8000, type=int, help="Acquirium server port")
+    parser.add_argument("--interval", default=10.0, type=float, help="Seconds between samples")
+    args = parser.parse_args()
+
+    aq = Acquirium(server_url=args.url, server_port=args.port)
+
+    register_streams(aq)
+
+    print(f"Publishing to {args.url}:{args.port} every {args.interval}s")
+
+    # Warm up cpu_percent (first call always returns 0.0)
+    psutil.cpu_percent(interval=None)
+
+    while True:
+        ts = datetime.now(tz=timezone.utc)
+        sample = collect()
+
+        streams = {uri: [(ts, value)] for uri, value in sample.items()}
+        result = aq.insert_timeseries_batch(streams)
+
+        print(f"[{ts.isoformat()}] inserted {result.get('rows_inserted', '?')} rows")
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_system_metrics.py
+++ b/scripts/publish_system_metrics.py
@@ -25,11 +25,11 @@ from acquirium.internals.internals_namespaces import (
     ACQUIRIUM_DB_URI,
     ACQUIRIUM_REF_NAME,
     ACQUIRIUM_SOURCE_ID,
-    BRICK_REF_DATABASE,
-    BRICK_REF_HAS_EXTERNAL_REFERENCE,
-    BRICK_REF_HAS_TIMESERIES_ID,
-    BRICK_REF_STORED_AT,
-    BRICK_REF_TIMESERIES_REFERENCE,
+    DATABASE,
+    HAS_EXTERNAL_REFERENCE,
+    HAS_TIMESERIES_ID,
+    STORED_AT,
+    TIMESERIES_REFERENCE,
     S223,
     VIRTUAL_POINT,
 )
@@ -111,16 +111,16 @@ def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
         <urn:host:{hostname}:cpu_percent#ref>
             a ref:TimeseriesReference ;
             ref:hasTimeseriesId "{hostname}:cpu_percent" ;
-            ref:storedAt <urn:acquirium:timescaledb> .
+            ref:storedAt <urn:acquirium#timescaledb> .
 
-        <urn:acquirium:timescaledb>  a  ref:Database .
+        <urn:acquirium#timescaledb>  a <urn:acquirium#Database> .
     """
     hostname = host["hostname"]
     g = Graph()
     h = host_uri(hostname)
 
     # Declare the Acquirium DB node once per graph (idempotent across calls)
-    g.add((ACQUIRIUM_DB_URI, RDF.type,   BRICK_REF_DATABASE))
+    g.add((ACQUIRIUM_DB_URI, RDF.type,   DATABASE))
     g.add((ACQUIRIUM_DB_URI, RDFS.label, Literal("Acquirium TimescaleDB")))
 
     # Host node
@@ -147,12 +147,12 @@ def register_host_graph(aq: Acquirium, host: dict, src_id: str) -> None:
 
         # Brick-style external reference → Acquirium TimescaleDB
         # ref:hasTimeseriesId holds the globally-unique handle (actual DB key)
-        g.add((s,        BRICK_REF_HAS_EXTERNAL_REFERENCE, ref_node))
-        g.add((ref_node, RDF.type,                         BRICK_REF_TIMESERIES_REFERENCE))
-        g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(handle)))
+        g.add((s,        HAS_EXTERNAL_REFERENCE, ref_node))
+        g.add((ref_node, RDF.type, TIMESERIES_REFERENCE))
+        g.add((ref_node, HAS_TIMESERIES_ID,      Literal(handle)))
         g.add((ref_node, ACQUIRIUM_SOURCE_ID,               Literal(src_id)))
         g.add((ref_node, ACQUIRIUM_REF_NAME,                Literal(key)))
-        g.add((ref_node, BRICK_REF_STORED_AT,               ACQUIRIUM_DB_URI))
+        g.add((ref_node, STORED_AT,               ACQUIRIUM_DB_URI))
 
     turtle = g.serialize(format="turtle")
     aq.client.insert_graph(turtle, format="turtle", replace=False)

--- a/src/acquirium/Apps/base.py
+++ b/src/acquirium/Apps/base.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterable
 
-from acquirium.internals.app_utils import make_stream_ref_uri
 from acquirium.internals.models import AppContext
 from acquirium.Client.query import Query
 
@@ -25,7 +24,6 @@ class Output:
         rows: Iterable[tuple[datetime, Any]] | None = None,
         series: Any | None = None,
         time_index: Iterable[datetime] | None = None,
-        ref_uri: str | None = None,
     ) -> "Output":
         if rows is None:
             if series is None:
@@ -44,8 +42,7 @@ class Output:
                 if len(times) != len(values):
                     raise ValueError("time_index length must match series length")
                 rows = list(zip(times, values))
-        ref_uri = ref_uri or make_stream_ref_uri(point_uri)
-        return Output(kind="timeseries", payload={"point_uri": point_uri, "ref_uri": ref_uri, "rows": list(rows)})
+        return Output(kind="timeseries", payload={"point_uri": point_uri, "rows": list(rows)})
 
     @staticmethod
     def event(
@@ -55,17 +52,14 @@ class Output:
         message: str,
         ts: datetime | None = None,
         data: dict[str, Any] | None = None,
-        ref_uri: str | None = None,
     ) -> "Output":
         if point_uri is None:
             raise ValueError("event output requires point_uri")
-        ref_uri = ref_uri or make_stream_ref_uri(point_uri)
         ts = ts or datetime.now(timezone.utc)
         return Output(
             kind="event",
             payload={
                 "point_uri": point_uri,
-                "ref_uri": ref_uri,
                 "severity": severity,
                 "message": message,
                 "ts": ts,

--- a/src/acquirium/Apps/worker.py
+++ b/src/acquirium/Apps/worker.py
@@ -14,7 +14,6 @@ import time
 
 from acquirium import Acquirium
 from acquirium.Apps.base import Output, App
-from acquirium.internals.app_utils import make_stream_ref_uri
 from acquirium.internals.models import AppContext
 
 # Configure logging for container output
@@ -145,7 +144,7 @@ def _run_once(app: App, ctx: AppContext, aq: Acquirium, run_count: int = 0) -> i
         outputs = app.run(ctx)
         elapsed = time.time() - start_time
         logger.info("Run #%d completed in %.3fs, produced %d outputs", run_count, elapsed, len(outputs))
-        _persist_outputs(aq, outputs)
+        _persist_outputs(aq, ctx.app_id, outputs)
         return run_count
     except Exception as e:
         elapsed = time.time() - start_time
@@ -259,18 +258,16 @@ def _load_app(module: str, class_name: str, params: dict[str, Any]) -> App:
     return app
 
 
-def _persist_outputs(aq: Acquirium, outputs: list[Output]) -> None:
+def _persist_outputs(aq: Acquirium, app_id: str, outputs: list[Output]) -> None:
     for i, out in enumerate(outputs):
         if out.kind == "timeseries":
             point_uri = out.payload["point_uri"]
-            ref_uri = out.payload.get("ref_uri") or make_stream_ref_uri(point_uri)
             rows = out.payload["rows"]
             logger.debug("Output %d: persisting %d timeseries rows to %s", i + 1, len(rows), point_uri)
-            aq.client.insert_timeseries(ref_uri=ref_uri, rows=rows, point_uri=point_uri)
+            aq.client.insert_timeseries(source_id=app_id, ref_name=point_uri, rows=rows, point_uri=point_uri)
             logger.info("Output %d: wrote %d timeseries rows to %s", i + 1, len(rows), point_uri)
         elif out.kind == "event":
             point_uri = out.payload["point_uri"]
-            ref_uri = out.payload.get("ref_uri") or make_stream_ref_uri(point_uri)
             ts = out.payload.get("ts") or datetime.now(timezone.utc)
             severity = out.payload.get("severity", "INFO")
             value = json.dumps(
@@ -281,7 +278,7 @@ def _persist_outputs(aq: Acquirium, outputs: list[Output]) -> None:
                 },
                 ensure_ascii=True,
             )
-            aq.client.insert_timeseries(ref_uri=ref_uri, rows=[(ts, value)], point_uri=point_uri)
+            aq.client.insert_timeseries(source_id=app_id, ref_name=point_uri, rows=[(ts, value)], point_uri=point_uri)
             logger.info("Output %d: emitted %s event to %s", i + 1, severity, point_uri)
         elif out.kind == "trigger":
             url = out.payload.get("url")

--- a/src/acquirium/Client/acquirium.py
+++ b/src/acquirium/Client/acquirium.py
@@ -17,15 +17,19 @@ from acquirium.Apps.base import App
 from acquirium.internals.app_utils import make_stream_ref_uri
 from acquirium.internals.models import AppOutputSpec, AppSpec
 from acquirium.internals.internals_namespaces import (
-    HAS_EXTERNAL_REFERENCE,
+    ACQUIRIUM_DB_URI,
+    BRICK_REF,
+    BRICK_REF_DATABASE,
+    BRICK_REF_HAS_EXTERNAL_REFERENCE,
+    BRICK_REF_HAS_TIMESERIES_ID,
+    BRICK_REF_STORED_AT,
+    BRICK_REF_TIMESERIES_REFERENCE,
     HAS_MEDIUM,
     HAS_QUANTITY_KIND,
     HAS_UNIT,
     OF_SUBSTANCE,
-    TIMESERIES_STREAM,
     VIRTUAL_POINT,
     DATA_SOURCE,
-    STREAM,
 )
 @dataclass
 class Acquirium:
@@ -103,25 +107,29 @@ class Acquirium:
 
     def insert_timeseries(
         self,
-        ref_uri: str,
+        ref_name: str,
         rows: list[tuple[datetime, Any]],
         *,
         point_uri: Optional[str] = None,
         replace: bool = False,
     ) -> dict[str, Any]:
-        """Insert timeseries data for a given reference URI.
+        """Insert timeseries data for a stream.
 
         Args:
-            ref_uri: The URI identifying the data stream (e.g. a sensor or point URI).
-            rows: List of (timestamp, value) tuples. Values may be float, int, str, or None.
-            point_uri: Optional override URI for the timeseries point. Defaults to ref_uri.
-            replace: If True, replaces any existing data for this stream. Default False.
+            ref_name: The source-native identifier for this stream (e.g. a sensor
+                tag, MQTT topic, or database column name). Used as the storage key
+                in TimescaleDB and matched against ``ref:hasTimeseriesId`` in the graph.
+            rows: List of (timestamp, value) tuples.
+            point_uri: The semantic URI of the measurement point in the knowledge
+                graph. When provided, a handle mapping is registered in the streams
+                table linking point_uri to ref_name.
+            replace: If True, replaces any existing data for this stream.
 
         Returns:
             dict with ``{"ok": True, "rows_inserted": N}``.
         """
         return self.client.insert_timeseries(
-            ref_uri=ref_uri,
+            ref_name=ref_name,
             rows=rows,
             point_uri=point_uri,
             replace=replace,
@@ -134,7 +142,9 @@ class Acquirium:
         """Insert timeseries data for multiple streams in one HTTP request.
 
         Args:
-            streams: Mapping of point URI → list of (timestamp, value) tuples.
+            streams: Mapping of ref_name → list of (timestamp, value) tuples.
+                ``ref_name`` is the source-native identifier (e.g. sensor tag,
+                MQTT topic) used as the TimescaleDB storage key.
 
         Returns:
             dict with ``{"ok": True, "rows_inserted": N}``.
@@ -174,12 +184,12 @@ class Acquirium:
         point_uri: str | URIRef,
         label: str | None = None,
         *,
+        ref_name: str | None = None,
         unit: str | URIRef | None = None,
         quantity_kind: str | URIRef | None = None,
         medium: str | URIRef | None = None,
         substance: str | URIRef | None = None,
         data_source: str | URIRef | None = None,
-        external_reference: str | URIRef | None = None,
         properties: dict[URIRef, str | URIRef] | None = None,
     ) -> None:
         """Declare a stream's semantic metadata in the RDF graph.
@@ -188,28 +198,36 @@ class Acquirium:
         any supplied metadata predicates. Call this once (or when metadata
         changes); it does not affect stored timeseries values.
 
+        When ``ref_name`` is provided, a Brick-style external reference is
+        written following the pattern from the Brick timeseries storage spec
+        (https://docs.brickschema.org/metadata/timeseries-storage.html)::
+
+            <point_uri>  ref:hasExternalReference  <point_uri#ref> .
+            <point_uri#ref>  a  ref:TimeseriesReference ;
+                             ref:hasTimeseriesId  "{ref_name}" ;
+                             ref:storedAt  <urn:acquirium:timescaledb> .
+            <urn:acquirium:timescaledb>  a  ref:Database .
+
+        The ``ref_name`` value is what ``_sync_stream_handles_from_graph``
+        reads back to populate the streams handle table.
+
         Plain strings for ``unit``, ``quantity_kind``, ``medium``, and
         ``substance`` are resolved against the QUDT vocabulary via the server
-        (unit resolver + embedding matcher).  If resolution succeeds the
-        matching QUDT URI is written as an RDF resource; otherwise the string
-        is written as a plain literal with a warning.
+        (unit resolver + embedding matcher). Falls back to a plain literal with
+        a warning if no confident match is found.
 
         Args:
             point_uri: The URI identifying this stream in the knowledge graph.
-            label: Human-readable name (written as rdfs:label).
-            unit: Unit of measurement — URIRef, URI string, or plain text
-                (e.g. ``"mg/L"``, ``"%"``, ``"byte"``).
-            quantity_kind: Physical quantity — URIRef, URI string, or plain text
-                (e.g. ``"Mass Concentration"``).
+            label: Human-readable name (rdfs:label).
+            ref_name: Source-native identifier for this stream (sensor tag,
+                MQTT topic, database column, etc.). Written as
+                ``ref:hasTimeseriesId`` on the external reference node.
+            unit: Unit of measurement — URIRef, URI string, or plain text.
+            quantity_kind: Physical quantity — URIRef, URI string, or plain text.
             medium: Medium the measurement applies to (S223 hasMedium).
             substance: Substance being measured (S223 ofSubstance).
             data_source: Origin of the data — written as a literal string.
-            external_reference: URI of the backing data reference node
-                (``acquirium:hasExternalReference``).  A
-                ``acquirium:TimeseriesStream`` triple is also added.
             properties: Arbitrary extra triples as ``{predicate_uri: value}``.
-                Values that are URIRef (or URI-like strings) are written as
-                RDF resources; plain strings are written as literals.
         """
         g = RDFGraph()
         subj = URIRef(str(point_uri))
@@ -219,8 +237,7 @@ class Acquirium:
             g.add((subj, RDFS.label, Literal(label)))
 
         def _coerce(value: str | URIRef | None, qudt_kind: str) -> str | URIRef | None:
-            """Resolve a plain string to a QUDT URIRef, leaving URIRefs and URI
-            strings untouched and falling back to the original string on failure."""
+            """Resolve a plain string to a QUDT URIRef, falling back to literal."""
             if value is None or isinstance(value, URIRef):
                 return value
             if "://" in value or value.startswith("urn:"):
@@ -250,11 +267,17 @@ class Acquirium:
         _add(OF_SUBSTANCE,      _coerce(substance,     "class"))
         _add(DATA_SOURCE, data_source)
 
-        if external_reference is not None:
-            ref = URIRef(str(external_reference))
-            g.add((subj, HAS_EXTERNAL_REFERENCE, ref))
-            g.add((ref, RDF.type, STREAM))
-            g.add((ref, RDF.type, TIMESERIES_STREAM))
+        if ref_name is not None:
+            # Brick-style timeseries external reference — use a stable named
+            # URI for the reference node so repeated calls are idempotent.
+            ref_node = URIRef(str(point_uri) + "#ref")
+            g.add((subj,     BRICK_REF_HAS_EXTERNAL_REFERENCE, ref_node))
+            g.add((ref_node, RDF.type,                         BRICK_REF_TIMESERIES_REFERENCE))
+            g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(ref_name)))
+            g.add((ref_node, BRICK_REF_STORED_AT,              ACQUIRIUM_DB_URI))
+            # Declare the Acquirium DB node (idempotent)
+            g.add((ACQUIRIUM_DB_URI, RDF.type,   BRICK_REF_DATABASE))
+            g.add((ACQUIRIUM_DB_URI, RDFS.label, Literal("Acquirium TimescaleDB")))
 
         for pred, value in (properties or {}).items():
             _add(pred, value)

--- a/src/acquirium/Client/acquirium.py
+++ b/src/acquirium/Client/acquirium.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterable, Sequence, Callable, Optional
+from typing import Any, Iterable, Sequence, Callable, Optional, TYPE_CHECKING
 import inspect
+
+if TYPE_CHECKING:
+    import polars as pl
 
 from rdflib import Graph as RDFGraph, URIRef, Literal
 from rdflib.namespace import RDF, RDFS
@@ -18,15 +21,12 @@ from acquirium.internals.app_utils import make_stream_ref_uri
 from acquirium.internals.models import AppOutputSpec, AppSpec, compute_handle
 from acquirium.internals.internals_namespaces import (
     ACQUIRIUM_DB_URI,
-    ACQUIRIUM_DATASOURCE,
-    ACQUIRIUM_NS,
     ACQUIRIUM_REF_NAME,
     ACQUIRIUM_SOURCE_ID,
-    BRICK_REF_DATABASE,
-    BRICK_REF_HAS_EXTERNAL_REFERENCE,
-    BRICK_REF_HAS_TIMESERIES_ID,
-    BRICK_REF_STORED_AT,
-    BRICK_REF_TIMESERIES_REFERENCE,
+    HAS_TIMESERIES_ID,
+    STORED_AT,
+    TIMESERIES_REFERENCE,
+    HAS_EXTERNAL_REFERENCE,
     HAS_MEDIUM,
     HAS_QUANTITY_KIND,
     HAS_UNIT,
@@ -52,7 +52,7 @@ class Acquirium:
             server_port: int = 8000,
             use_ssl: bool = False,
             lexicon_path: Optional[Path] = None,
-        ) -> Acquirium:
+        ):
         if lexicon_path is not None:
             warnings.warn(
                 "lexicon_path is deprecated and ignored. "
@@ -222,8 +222,8 @@ class Acquirium:
             <point_uri>  ref:hasExternalReference  <point_uri#ref> .
             <point_uri#ref>  a  ref:TimeseriesReference ;
                              ref:hasTimeseriesId  "{ref_name}" ;
-                             ref:storedAt  <urn:acquirium:timescaledb> .
-            <urn:acquirium:timescaledb>  a  ref:Database .
+                             ref:storedAt  <urn:acquirium#timescaledb> .
+            <urn:acquirium#timescaledb>  a <urn:acquirium#Database> .
 
         The ``ref_name`` value is what ``_sync_stream_handles_from_graph``
         reads back to populate the streams handle table.
@@ -288,17 +288,16 @@ class Acquirium:
             handle = compute_handle(source_id, ref_name)
             # Stable named URI for the reference node — idempotent across calls
             ref_node = URIRef(str(point_uri) + "#ref")
-            g.add((subj,     BRICK_REF_HAS_EXTERNAL_REFERENCE, ref_node))
-            g.add((ref_node, RDF.type,                         BRICK_REF_TIMESERIES_REFERENCE))
+            g.add((subj,        HAS_EXTERNAL_REFERENCE, ref_node))
+            g.add((ref_node,    RDF.type,               TIMESERIES_REFERENCE))
             # ref:hasTimeseriesId holds the globally-unique handle (the actual DB key)
-            g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(handle)))
+            g.add((ref_node,    HAS_TIMESERIES_ID,      Literal(handle)))
             # Store source_id and ref_name so the handle can be reconstructed
             # by _sync_stream_handles_from_graph without re-deriving it
-            g.add((ref_node, ACQUIRIUM_SOURCE_ID,               Literal(source_id)))
-            g.add((ref_node, ACQUIRIUM_REF_NAME,                Literal(ref_name)))
-            g.add((ref_node, BRICK_REF_STORED_AT,               ACQUIRIUM_DB_URI))
+            g.add((ref_node,    ACQUIRIUM_SOURCE_ID,    Literal(source_id)))
+            g.add((ref_node,    ACQUIRIUM_REF_NAME,     Literal(ref_name)))
+            g.add((ref_node,    STORED_AT,              ACQUIRIUM_DB_URI))
             # Declare the Acquirium DB node (idempotent)
-            g.add((ACQUIRIUM_DB_URI, RDF.type,   BRICK_REF_DATABASE))
             g.add((ACQUIRIUM_DB_URI, RDFS.label, Literal("Acquirium TimescaleDB")))
 
         for pred, value in (properties or {}).items():
@@ -460,7 +459,7 @@ class Acquirium:
         log_time_end: str | datetime | None = None,
         observation_start: str | datetime | None = None,
         observation_end: str | datetime | None = None,
-    ) -> list:
+    ) -> "pl.DataFrame":
         """Read plant-level log entries (no query/object needed).
 
         Returns a list of LogEntry objects for the generic plant URI.

--- a/src/acquirium/Client/acquirium.py
+++ b/src/acquirium/Client/acquirium.py
@@ -17,7 +17,6 @@ import warnings
 from acquirium.Client.query import Query
 from acquirium.Client.client import AcquiriumClient
 from acquirium.Apps.base import App
-from acquirium.internals.app_utils import make_stream_ref_uri
 from acquirium.internals.models import AppOutputSpec, AppSpec, compute_handle
 from acquirium.internals.internals_namespaces import (
     ACQUIRIUM_DB_URI,
@@ -344,8 +343,6 @@ class Acquirium:
                 spec_item = AppOutputSpec(**item)
             else:
                 raise TypeError("outputs must be AppOutputSpec or dict")
-            if spec_item.ref_uri is None:
-                spec_item.ref_uri = make_stream_ref_uri(spec_item.point_uri)
             output_specs.append(spec_item)
 
         code = source_code or getattr(app, "source_code", None)

--- a/src/acquirium/Client/acquirium.py
+++ b/src/acquirium/Client/acquirium.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence, Callable, Optional
 import inspect
 
-from rdflib import Graph as RDFGraph, URIRef
+from rdflib import Graph as RDFGraph, URIRef, Literal
+from rdflib.namespace import RDF, RDFS
 
 import warnings
 
@@ -15,6 +16,17 @@ from acquirium.Client.client import AcquiriumClient
 from acquirium.Apps.base import App
 from acquirium.internals.app_utils import make_stream_ref_uri
 from acquirium.internals.models import AppOutputSpec, AppSpec
+from acquirium.internals.internals_namespaces import (
+    HAS_EXTERNAL_REFERENCE,
+    HAS_MEDIUM,
+    HAS_QUANTITY_KIND,
+    HAS_UNIT,
+    OF_SUBSTANCE,
+    TIMESERIES_STREAM,
+    VIRTUAL_POINT,
+    DATA_SOURCE,
+    STREAM,
+)
 @dataclass
 class Acquirium:
     """
@@ -89,6 +101,166 @@ class Acquirium:
     # TIMESERIES API
     # ------------------------------------------------------------------
 
+    def insert_timeseries(
+        self,
+        ref_uri: str,
+        rows: list[tuple[datetime, Any]],
+        *,
+        point_uri: Optional[str] = None,
+        replace: bool = False,
+    ) -> dict[str, Any]:
+        """Insert timeseries data for a given reference URI.
+
+        Args:
+            ref_uri: The URI identifying the data stream (e.g. a sensor or point URI).
+            rows: List of (timestamp, value) tuples. Values may be float, int, str, or None.
+            point_uri: Optional override URI for the timeseries point. Defaults to ref_uri.
+            replace: If True, replaces any existing data for this stream. Default False.
+
+        Returns:
+            dict with ``{"ok": True, "rows_inserted": N}``.
+        """
+        return self.client.insert_timeseries(
+            ref_uri=ref_uri,
+            rows=rows,
+            point_uri=point_uri,
+            replace=replace,
+        )
+
+    def insert_timeseries_batch(
+        self,
+        streams: dict[str, list[tuple[datetime, Any]]],
+    ) -> dict[str, Any]:
+        """Insert timeseries data for multiple streams in one HTTP request.
+
+        Args:
+            streams: Mapping of point URI → list of (timestamp, value) tuples.
+
+        Returns:
+            dict with ``{"ok": True, "rows_inserted": N}``.
+        """
+        return self.client.insert_timeseries_batch(streams)
+
+    def _resolve_qudt_uri(self, text: str, kind: str) -> URIRef | None:
+        """Try to resolve a plain string to a QUDT URI via the server.
+
+        For ``kind="unit"`` the deterministic unit resolver is tried first
+        (handles symbols, UCUM codes, and ratio notation like "mg/L"), then
+        the embedding matcher as a fallback.  For other kinds (``"quantity_kind"``,
+        ``"class"``) only the embedding matcher is used.
+
+        Returns a URIRef on success, or None if no confident match is found.
+        """
+        if kind == "unit":
+            try:
+                result = self.client.resolve_unit(text)
+                uri = result.get("uri")
+                if uri:
+                    return URIRef(uri)
+            except Exception:
+                pass  # fall through to embedding matcher
+
+        try:
+            matches = self.client.resolve_text(text, kind=kind, top_k=1, min_score=0.6)
+            if matches:
+                return URIRef(matches[0]["uri"])
+        except Exception:
+            pass
+
+        return None
+
+    def register_stream(
+        self,
+        point_uri: str | URIRef,
+        label: str | None = None,
+        *,
+        unit: str | URIRef | None = None,
+        quantity_kind: str | URIRef | None = None,
+        medium: str | URIRef | None = None,
+        substance: str | URIRef | None = None,
+        data_source: str | URIRef | None = None,
+        external_reference: str | URIRef | None = None,
+        properties: dict[URIRef, str | URIRef] | None = None,
+    ) -> None:
+        """Declare a stream's semantic metadata in the RDF graph.
+
+        Registers a point URI as a timeseries stream and annotates it with
+        any supplied metadata predicates. Call this once (or when metadata
+        changes); it does not affect stored timeseries values.
+
+        Plain strings for ``unit``, ``quantity_kind``, ``medium``, and
+        ``substance`` are resolved against the QUDT vocabulary via the server
+        (unit resolver + embedding matcher).  If resolution succeeds the
+        matching QUDT URI is written as an RDF resource; otherwise the string
+        is written as a plain literal with a warning.
+
+        Args:
+            point_uri: The URI identifying this stream in the knowledge graph.
+            label: Human-readable name (written as rdfs:label).
+            unit: Unit of measurement — URIRef, URI string, or plain text
+                (e.g. ``"mg/L"``, ``"%"``, ``"byte"``).
+            quantity_kind: Physical quantity — URIRef, URI string, or plain text
+                (e.g. ``"Mass Concentration"``).
+            medium: Medium the measurement applies to (S223 hasMedium).
+            substance: Substance being measured (S223 ofSubstance).
+            data_source: Origin of the data — written as a literal string.
+            external_reference: URI of the backing data reference node
+                (``acquirium:hasExternalReference``).  A
+                ``acquirium:TimeseriesStream`` triple is also added.
+            properties: Arbitrary extra triples as ``{predicate_uri: value}``.
+                Values that are URIRef (or URI-like strings) are written as
+                RDF resources; plain strings are written as literals.
+        """
+        g = RDFGraph()
+        subj = URIRef(str(point_uri))
+
+        g.add((subj, RDF.type, VIRTUAL_POINT))
+        if label is not None:
+            g.add((subj, RDFS.label, Literal(label)))
+
+        def _coerce(value: str | URIRef | None, qudt_kind: str) -> str | URIRef | None:
+            """Resolve a plain string to a QUDT URIRef, leaving URIRefs and URI
+            strings untouched and falling back to the original string on failure."""
+            if value is None or isinstance(value, URIRef):
+                return value
+            if "://" in value or value.startswith("urn:"):
+                return URIRef(value)
+            resolved = self._resolve_qudt_uri(value, qudt_kind)
+            if resolved is None:
+                warnings.warn(
+                    f"Could not resolve {qudt_kind!r} value {value!r} to a QUDT URI; "
+                    "storing as a plain literal.",
+                    stacklevel=3,
+                )
+            return resolved or value
+
+        def _add(pred: URIRef, value: str | URIRef | None) -> None:
+            if value is None:
+                return
+            if isinstance(value, URIRef):
+                g.add((subj, pred, value))
+            elif "://" in value or value.startswith("urn:"):
+                g.add((subj, pred, URIRef(value)))
+            else:
+                g.add((subj, pred, Literal(value)))
+
+        _add(HAS_UNIT,          _coerce(unit,          "unit"))
+        _add(HAS_QUANTITY_KIND, _coerce(quantity_kind, "quantity_kind"))
+        _add(HAS_MEDIUM,        _coerce(medium,        "class"))
+        _add(OF_SUBSTANCE,      _coerce(substance,     "class"))
+        _add(DATA_SOURCE, data_source)
+
+        if external_reference is not None:
+            ref = URIRef(str(external_reference))
+            g.add((subj, HAS_EXTERNAL_REFERENCE, ref))
+            g.add((ref, RDF.type, STREAM))
+            g.add((ref, RDF.type, TIMESERIES_STREAM))
+
+        for pred, value in (properties or {}).items():
+            _add(pred, value)
+
+        turtle = g.serialize(format="turtle")
+        self.client.insert_graph(turtle, format="turtle", replace=False)
 
     # ------------------------------------------------------------------
     # ACQUIRIUM APPS API

--- a/src/acquirium/Client/acquirium.py
+++ b/src/acquirium/Client/acquirium.py
@@ -23,7 +23,6 @@ from acquirium.internals.internals_namespaces import (
     ACQUIRIUM_DB_URI,
     ACQUIRIUM_REF_NAME,
     ACQUIRIUM_SOURCE_ID,
-    HAS_TIMESERIES_ID,
     STORED_AT,
     TIMESERIES_REFERENCE,
     HAS_EXTERNAL_REFERENCE,
@@ -287,16 +286,13 @@ class Acquirium:
         if ref_name is not None and source_id is not None:
             handle = compute_handle(source_id, ref_name)
             # Stable named URI for the reference node — idempotent across calls
-            ref_node = URIRef(str(point_uri) + "#ref")
-            g.add((subj,        HAS_EXTERNAL_REFERENCE, ref_node))
-            g.add((ref_node,    RDF.type,               TIMESERIES_REFERENCE))
-            # ref:hasTimeseriesId holds the globally-unique handle (the actual DB key)
-            g.add((ref_node,    HAS_TIMESERIES_ID,      Literal(handle)))
+            g.add((subj,        HAS_EXTERNAL_REFERENCE, handle))
+            g.add((handle,    RDF.type,               TIMESERIES_REFERENCE))
             # Store source_id and ref_name so the handle can be reconstructed
             # by _sync_stream_handles_from_graph without re-deriving it
-            g.add((ref_node,    ACQUIRIUM_SOURCE_ID,    Literal(source_id)))
-            g.add((ref_node,    ACQUIRIUM_REF_NAME,     Literal(ref_name)))
-            g.add((ref_node,    STORED_AT,              ACQUIRIUM_DB_URI))
+            g.add((handle,    ACQUIRIUM_SOURCE_ID,    Literal(source_id)))
+            g.add((handle,    ACQUIRIUM_REF_NAME,     Literal(ref_name)))
+            g.add((handle,    STORED_AT,              ACQUIRIUM_DB_URI))
             # Declare the Acquirium DB node (idempotent)
             g.add((ACQUIRIUM_DB_URI, RDFS.label, Literal("Acquirium TimescaleDB")))
 

--- a/src/acquirium/Client/acquirium.py
+++ b/src/acquirium/Client/acquirium.py
@@ -15,10 +15,13 @@ from acquirium.Client.query import Query
 from acquirium.Client.client import AcquiriumClient
 from acquirium.Apps.base import App
 from acquirium.internals.app_utils import make_stream_ref_uri
-from acquirium.internals.models import AppOutputSpec, AppSpec
+from acquirium.internals.models import AppOutputSpec, AppSpec, compute_handle
 from acquirium.internals.internals_namespaces import (
     ACQUIRIUM_DB_URI,
-    BRICK_REF,
+    ACQUIRIUM_DATASOURCE,
+    ACQUIRIUM_NS,
+    ACQUIRIUM_REF_NAME,
+    ACQUIRIUM_SOURCE_ID,
     BRICK_REF_DATABASE,
     BRICK_REF_HAS_EXTERNAL_REFERENCE,
     BRICK_REF_HAS_TIMESERIES_ID,
@@ -105,30 +108,43 @@ class Acquirium:
     # TIMESERIES API
     # ------------------------------------------------------------------
 
+    def register_datasource(self, source_id: str) -> str:
+        """Register a named datasource in the knowledge graph.
+
+        The ``source_id`` is a user-provided string that scopes stream
+        ``ref_name`` values so two sources with the same ``ref_name`` never
+        produce colliding TimescaleDB keys.  Safe to call on every startup —
+        the graph write is idempotent.
+
+        Returns ``source_id``.
+        """
+        return self.client.register_datasource(source_id)
+
     def insert_timeseries(
         self,
+        source_id: str,
         ref_name: str,
         rows: list[tuple[datetime, Any]],
         *,
         point_uri: Optional[str] = None,
         replace: bool = False,
     ) -> dict[str, Any]:
-        """Insert timeseries data for a stream.
+        """Insert timeseries data for a single stream.
 
         Args:
-            ref_name: The source-native identifier for this stream (e.g. a sensor
-                tag, MQTT topic, or database column name). Used as the storage key
-                in TimescaleDB and matched against ``ref:hasTimeseriesId`` in the graph.
+            source_id: The registered datasource identifier.
+            ref_name: The source-local stream identifier. Combined with
+                ``source_id`` to derive the unique TimescaleDB storage key.
             rows: List of (timestamp, value) tuples.
-            point_uri: The semantic URI of the measurement point in the knowledge
-                graph. When provided, a handle mapping is registered in the streams
-                table linking point_uri to ref_name.
+            point_uri: Semantic URI of the measurement point. When provided,
+                a handle mapping is registered in the streams table.
             replace: If True, replaces any existing data for this stream.
 
         Returns:
             dict with ``{"ok": True, "rows_inserted": N}``.
         """
         return self.client.insert_timeseries(
+            source_id=source_id,
             ref_name=ref_name,
             rows=rows,
             point_uri=point_uri,
@@ -137,19 +153,19 @@ class Acquirium:
 
     def insert_timeseries_batch(
         self,
+        source_id: str,
         streams: dict[str, list[tuple[datetime, Any]]],
     ) -> dict[str, Any]:
         """Insert timeseries data for multiple streams in one HTTP request.
 
         Args:
+            source_id: The registered datasource identifier.
             streams: Mapping of ref_name → list of (timestamp, value) tuples.
-                ``ref_name`` is the source-native identifier (e.g. sensor tag,
-                MQTT topic) used as the TimescaleDB storage key.
 
         Returns:
             dict with ``{"ok": True, "rows_inserted": N}``.
         """
-        return self.client.insert_timeseries_batch(streams)
+        return self.client.insert_timeseries_batch(source_id, streams)
 
     def _resolve_qudt_uri(self, text: str, kind: str) -> URIRef | None:
         """Try to resolve a plain string to a QUDT URI via the server.
@@ -184,6 +200,7 @@ class Acquirium:
         point_uri: str | URIRef,
         label: str | None = None,
         *,
+        source_id: str | None = None,
         ref_name: str | None = None,
         unit: str | URIRef | None = None,
         quantity_kind: str | URIRef | None = None,
@@ -267,14 +284,19 @@ class Acquirium:
         _add(OF_SUBSTANCE,      _coerce(substance,     "class"))
         _add(DATA_SOURCE, data_source)
 
-        if ref_name is not None:
-            # Brick-style timeseries external reference — use a stable named
-            # URI for the reference node so repeated calls are idempotent.
+        if ref_name is not None and source_id is not None:
+            handle = compute_handle(source_id, ref_name)
+            # Stable named URI for the reference node — idempotent across calls
             ref_node = URIRef(str(point_uri) + "#ref")
             g.add((subj,     BRICK_REF_HAS_EXTERNAL_REFERENCE, ref_node))
             g.add((ref_node, RDF.type,                         BRICK_REF_TIMESERIES_REFERENCE))
-            g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(ref_name)))
-            g.add((ref_node, BRICK_REF_STORED_AT,              ACQUIRIUM_DB_URI))
+            # ref:hasTimeseriesId holds the globally-unique handle (the actual DB key)
+            g.add((ref_node, BRICK_REF_HAS_TIMESERIES_ID,      Literal(handle)))
+            # Store source_id and ref_name so the handle can be reconstructed
+            # by _sync_stream_handles_from_graph without re-deriving it
+            g.add((ref_node, ACQUIRIUM_SOURCE_ID,               Literal(source_id)))
+            g.add((ref_node, ACQUIRIUM_REF_NAME,                Literal(ref_name)))
+            g.add((ref_node, BRICK_REF_STORED_AT,               ACQUIRIUM_DB_URI))
             # Declare the Acquirium DB node (idempotent)
             g.add((ACQUIRIUM_DB_URI, RDF.type,   BRICK_REF_DATABASE))
             g.add((ACQUIRIUM_DB_URI, RDFS.label, Literal("Acquirium TimescaleDB")))

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -441,8 +441,8 @@ class AcquiriumClient:
         replace: bool = False,
     ) -> dict:
         url = f"{self.base_url}/insert_timeseries"
-        payload = [StreamInsert(source_id=source_id, ref_name=ref_name, point_uri=point_uri, replace=replace, values=rows)]
-        response = requests.post(url, json=[s.model_dump(mode="json") for s in payload])
+        body = StreamInsert(source_id=source_id, ref_name=ref_name, point_uri=point_uri, replace=replace, values=rows)
+        response = requests.post(url, json=[body.model_dump(mode="json")])
         response.raise_for_status()
         return response.json()
 

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -426,13 +426,13 @@ class AcquiriumClient:
     def insert_timeseries(
         self,
         *,
-        ref_uri: str,
+        ref_name: str,
         rows: list[tuple[datetime, Any]],
         point_uri: Optional[str] = None,
         replace: bool = False,
     ) -> dict:
         url = f"{self.base_url}/insert_timeseries"
-        payload = [StreamInsert(ref_uri=ref_uri, point_uri=point_uri, replace=replace, values=rows)]
+        payload = [StreamInsert(ref_name=ref_name, point_uri=point_uri, replace=replace, values=rows)]
         response = requests.post(url, json=[s.model_dump(mode="json") for s in payload])
         response.raise_for_status()
         return response.json()
@@ -444,10 +444,10 @@ class AcquiriumClient:
         """Insert timeseries data for multiple streams in one HTTP request.
 
         Args:
-            streams: Mapping of point URI → list of (timestamp, value) tuples.
+            streams: Mapping of ref_name → list of (timestamp, value) tuples.
         """
         url = f"{self.base_url}/insert_timeseries"
-        payload = [StreamInsert(ref_uri=uri, values=rows) for uri, rows in streams.items()]
+        payload = [StreamInsert(ref_name=ref_name, values=rows) for ref_name, rows in streams.items()]
         response = requests.post(url, json=[s.model_dump(mode="json") for s in payload])
         response.raise_for_status()
         return response.json()

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -12,6 +12,7 @@ from acquirium.internals.models import (
     AppRunRequest,
     AppStopRequest,
     InsertTimeseriesRequest,
+    InsertBatchRequest,
 )
 from acquirium.internals.internals_namespaces import *
 from acquirium.Grafana.grafana_dashboard_creator import GrafanaDashboardCreator
@@ -439,7 +440,22 @@ class AcquiriumClient:
         response = requests.post(url, params=params, json=req.model_dump(mode="json"))
         response.raise_for_status()
         return response.json()
-    
+
+    def insert_timeseries_batch(
+        self,
+        streams: dict[str, list[tuple[datetime, Any]]],
+    ) -> dict:
+        """Insert timeseries data for multiple streams in one HTTP request.
+
+        Args:
+            streams: Mapping of point URI → list of (timestamp, value) tuples.
+        """
+        url = f"{self.base_url}/insert_timeseries_batch"
+        req = InsertBatchRequest(streams)
+        response = requests.post(url, json=req.model_dump(mode="json"))
+        response.raise_for_status()
+        return response.json()
+
     def query_logs(
         self,
         point_uri: Optional[str] = None,

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -12,6 +12,7 @@ from acquirium.internals.models import (
     AppRunRequest,
     AppStopRequest,
     StreamInsert,
+    RegisterDatasourceRequest,
 )
 from acquirium.internals.internals_namespaces import *
 from acquirium.Grafana.grafana_dashboard_creator import GrafanaDashboardCreator
@@ -423,31 +424,41 @@ class AcquiriumClient:
         response.raise_for_status()
         return response.json()
 
+    def register_datasource(self, source_id: str) -> str:
+        """Register a named datasource. Returns source_id."""
+        url = f"{self.base_url}/register_datasource"
+        response = requests.post(url, json=RegisterDatasourceRequest(source_id=source_id).model_dump())
+        response.raise_for_status()
+        return response.json()["source_id"]
+
     def insert_timeseries(
         self,
         *,
+        source_id: str,
         ref_name: str,
         rows: list[tuple[datetime, Any]],
         point_uri: Optional[str] = None,
         replace: bool = False,
     ) -> dict:
         url = f"{self.base_url}/insert_timeseries"
-        payload = [StreamInsert(ref_name=ref_name, point_uri=point_uri, replace=replace, values=rows)]
+        payload = [StreamInsert(source_id=source_id, ref_name=ref_name, point_uri=point_uri, replace=replace, values=rows)]
         response = requests.post(url, json=[s.model_dump(mode="json") for s in payload])
         response.raise_for_status()
         return response.json()
 
     def insert_timeseries_batch(
         self,
+        source_id: str,
         streams: dict[str, list[tuple[datetime, Any]]],
     ) -> dict:
         """Insert timeseries data for multiple streams in one HTTP request.
 
         Args:
+            source_id: The registered datasource identifier.
             streams: Mapping of ref_name → list of (timestamp, value) tuples.
         """
         url = f"{self.base_url}/insert_timeseries"
-        payload = [StreamInsert(ref_name=ref_name, values=rows) for ref_name, rows in streams.items()]
+        payload = [StreamInsert(source_id=source_id, ref_name=rn, values=rows) for rn, rows in streams.items()]
         response = requests.post(url, json=[s.model_dump(mode="json") for s in payload])
         response.raise_for_status()
         return response.json()

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -11,8 +11,7 @@ from acquirium.internals.models import (
     AppSpec,
     AppRunRequest,
     AppStopRequest,
-    InsertTimeseriesRequest,
-    InsertBatchRequest,
+    StreamInsert,
 )
 from acquirium.internals.internals_namespaces import *
 from acquirium.Grafana.grafana_dashboard_creator import GrafanaDashboardCreator
@@ -433,11 +432,8 @@ class AcquiriumClient:
         replace: bool = False,
     ) -> dict:
         url = f"{self.base_url}/insert_timeseries"
-        params = {"ref_uri": ref_uri, "replace": replace}
-        if point_uri:
-            params["point_uri"] = point_uri
-        req = InsertTimeseriesRequest(values=rows)
-        response = requests.post(url, params=params, json=req.model_dump(mode="json"))
+        payload = [StreamInsert(ref_uri=ref_uri, point_uri=point_uri, replace=replace, values=rows)]
+        response = requests.post(url, json=[s.model_dump(mode="json") for s in payload])
         response.raise_for_status()
         return response.json()
 
@@ -450,9 +446,9 @@ class AcquiriumClient:
         Args:
             streams: Mapping of point URI → list of (timestamp, value) tuples.
         """
-        url = f"{self.base_url}/insert_timeseries_batch"
-        req = InsertBatchRequest(streams)
-        response = requests.post(url, json=req.model_dump(mode="json"))
+        url = f"{self.base_url}/insert_timeseries"
+        payload = [StreamInsert(ref_uri=uri, values=rows) for uri, rows in streams.items()]
+        response = requests.post(url, json=[s.model_dump(mode="json") for s in payload])
         response.raise_for_status()
         return response.json()
 

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -283,19 +283,19 @@ class AcquiriumClient:
 
     def ingest_external_references_from_graph(self) -> dict:
         """
-        Query the server graph for CSV/Parquet external references.
-        Read those files locally (host filesystem) and upload bytes to server for ingestion.
-        Returns counts.
+        Query the server graph for ref:FileReference nodes (parquet/csv/tsv).
+        Read those files locally (host filesystem) and upload bytes to the
+        server for ingestion. The server infers the file format from the
+        filename extension.
         """
         q = f"""
-            SELECT ?data ?ref ?type ?path ?timeCol ?valueCol
+            SELECT ?data ?ref ?path ?timeCol ?valueCol
             WHERE {{
               ?data <{HAS_EXTERNAL_REFERENCE}> ?ref .
-              ?ref a ?type .
-              OPTIONAL {{ ?ref <{REF_PATH}> ?path . }}
-              OPTIONAL {{ ?ref <{REF_TIME_COL}> ?timeCol . }}
-              OPTIONAL {{ ?ref <{REF_VALUE_COL}> ?valueCol . }}
-              FILTER(?type IN (<{PARQUET_REF}>, <{CSV_REF}>))
+              ?ref a <{FILE_REFERENCE}> .
+              OPTIONAL {{ ?ref <{FILE_LOCATION}> ?path . }}
+              OPTIONAL {{ ?ref <{TIME_COLUMN_ID}> ?timeCol . }}
+              OPTIONAL {{ ?ref <{VALUE_COLUMN_ID}> ?valueCol . }}
             }}
         """
 
@@ -308,7 +308,7 @@ class AcquiriumClient:
 
         url = f"{self.base_url}/ingest_external_reference"
 
-        for data_uri, ref_uri, ref_type, path, time_col, value_col in rows:
+        for data_uri, ref_uri, path, time_col, value_col in rows:
             if not path:
                 skipped += 1
                 continue
@@ -326,21 +326,19 @@ class AcquiriumClient:
                 failed += 1
                 continue
 
-            time_column_no = int(str(time_col).strip('"')) if time_col else 0
-            value_column_no = int(str(value_col).strip('"')) if value_col else 1
-
             try:
                 with open(p, "rb") as f:
                     content = f.read()
 
                 files = {"file": (p.name, content, "application/octet-stream")}
-                data = {
+                data: dict[str, str] = {
                     "data_uri": str(data_uri),
                     "ref_uri": str(ref_uri),
-                    "ref_type": str(ref_type),
-                    "time_column_no": str(time_column_no),
-                    "value_column_no": str(value_column_no),
                 }
+                if time_col:
+                    data["time_column"] = str(time_col).strip('"')
+                if value_col:
+                    data["value_column"] = str(value_col).strip('"')
 
                 r = requests.post(url, data=data, files=files)
                 r.raise_for_status()

--- a/src/acquirium/Client/query.py
+++ b/src/acquirium/Client/query.py
@@ -174,7 +174,7 @@ class Query:
             return uri
         raise ValueError(f"{param} must be a URI (urn:..., http://..., or https://...)")
 
-    def _find_all_nodes(self, id_val=None) -> list[URIRef]:
+    def _find_all_nodes(self, id_val=None) -> set[URIRef]:
         '''
         Finds all nodes in the query result, except literals.
         If alias is provided, only nodes with that alias are returned.
@@ -192,7 +192,7 @@ class Query:
                 cell = row[col_index]
                 if isinstance(cell, str) and (cell.startswith("urn:")):
                     nodes.add(URIRef(cell))
-            return list(nodes)
+            return nodes
         else:
             for row in query_result.get("rows", []):
                 for cell in row:

--- a/src/acquirium/Client/query_graph.py
+++ b/src/acquirium/Client/query_graph.py
@@ -18,7 +18,7 @@ class QueryNode:
     - constraints: future extension (labels, numeric filters, instance_uri, etc.)
     """
     id: int
-    rdf_class: str = None
+    rdf_class: str | None = None
     alias: Optional[str] = None
     constraints: Dict[str, Any] = field(default_factory=dict)
 

--- a/src/acquirium/Dockerfile
+++ b/src/acquirium/Dockerfile
@@ -2,17 +2,21 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 WORKDIR /app
 
-#RUN apt-get update \
-#  && apt-get install -y --no-install-recommends docker.io ca-certificates \
-#  && rm -rf /var/lib/apt/lists/*
+# Copy dependency manifest first — this layer is only invalidated when
+# pyproject.toml changes, so source edits don't trigger a full dep reinstall.
+COPY pyproject.toml README.md .python-version ./
 
-COPY pyproject.toml /app/pyproject.toml
-COPY src /app/src
-COPY README.md /app/README.md
-COPY .python-version /app/.python-version
-COPY ontologies /app/ontologies
-RUN uv sync
+# Install dependencies but not the project itself.
+RUN uv sync --no-dev --no-install-project
 
+# Now copy source and ontologies; changes here only re-run the steps below.
+COPY src ./src
+COPY ontologies ./ontologies
+
+# Install the project itself into the already-populated venv.
+RUN uv sync --no-dev
+
+# Pre-warm the embedding model so the first request isn't slow.
 ENV FASTEMBED_CACHE_PATH=/app/.fastembed_cache
 RUN uv run python -c "from fastembed import TextEmbedding; TextEmbedding('BAAI/bge-small-en-v1.5')"
 

--- a/src/acquirium/Server/acq_app_runner.py
+++ b/src/acquirium/Server/acq_app_runner.py
@@ -12,7 +12,6 @@ import requests
 from acquirium.Apps.base import App, AppContext, Output
 from acquirium.Client.acquirium import Acquirium
 from acquirium.Client.query import Query
-from acquirium.internals.app_utils import make_stream_ref_uri
 from acquirium.Server.manager import Manager
 
 logger = logging.getLogger("acquirium.app_runner")
@@ -190,21 +189,19 @@ class AppRunner:
         )
 
         outputs = app.run(ctx)
-        self._persist(outputs)
+        self._persist(app_id, outputs)
         return outputs
 
     # ─────────────────────── persistence ───────────────────────
 
-    def _persist(self, outputs: list[Output]) -> None:
+    def _persist(self, app_id: str, outputs: list[Output]) -> None:
         for out in outputs:
             if out.kind == "timeseries":
                 point_uri = out.payload["point_uri"]
-                ref_uri = out.payload.get("ref_uri") or make_stream_ref_uri(point_uri)
                 rows = out.payload["rows"]
-                self.manager.insert_timeseries(ref_uri=ref_uri, rows=rows, point_uri=point_uri)
+                self.manager.insert_timeseries(source_id=app_id, ref_name=point_uri, rows=rows, point_uri=point_uri)
             elif out.kind == "event":
                 point_uri = out.payload["point_uri"]
-                ref_uri = out.payload.get("ref_uri") or make_stream_ref_uri(point_uri)
                 ts = out.payload.get("ts") or datetime.now(timezone.utc)
                 value = json.dumps(
                     {
@@ -214,7 +211,7 @@ class AppRunner:
                     },
                     ensure_ascii=True,
                 )
-                self.manager.insert_timeseries(ref_uri=ref_uri, rows=[(ts, value)], point_uri=point_uri)
+                self.manager.insert_timeseries(source_id=app_id, ref_name=point_uri, rows=[(ts, value)], point_uri=point_uri)
             elif out.kind == "trigger":
                 url = out.payload.get("url")
                 if not url:

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -289,9 +289,8 @@ def insert_timeseries(streams: Annotated[list[StreamInsert], Body()]) -> dict[st
 async def ingest_external_reference(
     data_uri: str = Form(...),
     ref_uri: str = Form(...),
-    ref_type: str = Form(...),          # PARQUET_REF or CSV_REF URI as string
-    time_column_no: int = Form(0),
-    value_column_no: int = Form(1),
+    time_column: str | None = Form(None),
+    value_column: str | None = Form(None),
     file: UploadFile = File(...),
 ) -> dict[str, Any]:
     try:
@@ -299,10 +298,9 @@ async def ingest_external_reference(
         n = app.state.manager.ingest_reference_bytes(
             data_uri=data_uri,
             ref_uri=ref_uri,
-            ref_type=ref_type,
             content=content,
-            time_column_no=time_column_no,
-            value_column_no=value_column_no,
+            time_column=time_column,
+            value_column=value_column,
             filename=file.filename or "upload",
         )
         return {"ok": True, "rows_ingested": n}

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -257,8 +257,6 @@ def register_datasource(req: RegisterDatasourceRequest) -> dict[str, Any]:
     try:
         source_id = app.state.manager.register_datasource(req.source_id)
         return {"ok": True, "source_id": source_id}
-    except ValueError as e:
-        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -24,6 +24,7 @@ from acquirium.internals.models import (
     AppRunRequest,
     AppStopRequest,
     InsertTimeseriesRequest,
+    InsertBatchRequest,
 )
 from acquirium.internals.internals_namespaces import PLANT_URI
 
@@ -251,6 +252,22 @@ def insert_timeseries(
             replace=replace,
         )
         return {"ok": True, "rows_inserted": n}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.post("/insert_timeseries_batch")
+def insert_timeseries_batch(req: InsertBatchRequest) -> dict[str, Any]:
+    """Insert timeseries data for multiple streams in a single request.
+
+    The request body is a JSON object mapping each point URI to a list of
+    ``[timestamp, value]`` pairs.
+    """
+    try:
+        total = 0
+        for point_uri, rows in req.streams.items():
+            total += app.state.manager.insert_timeseries(ref_uri=point_uri, rows=rows)
+        return {"ok": True, "rows_inserted": total}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -98,6 +98,7 @@ async def lifespan(app: FastAPI):
         n = m._connect_mqtt_streams_from_graph()
         app.state.mqtt_subscriptions = n
         log.info("Started %d MQTT subscriptions from graph", n)
+        m._sync_stream_handles_from_graph()
     except Exception as e:
         log.exception("Startup failed: %s", e)
         # If startup fails, ensure we close and crash so Docker restart policy can help

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -24,6 +24,7 @@ from acquirium.internals.models import (
     AppRunRequest,
     AppStopRequest,
     StreamInsert,
+    RegisterDatasourceRequest,
 )
 from acquirium.internals.internals_namespaces import PLANT_URI
 
@@ -236,6 +237,20 @@ def list_app_runs(app_id: Optional[str] = None) -> dict[str, Any]:
 ##### TIMESERIES INGESTION API ENDPOINTS ####
 
 
+@app.post("/register_datasource")
+def register_datasource(req: RegisterDatasourceRequest) -> dict[str, Any]:
+    """Register a named datasource in the knowledge graph.
+
+    The source_id is a user-provided string that scopes stream ref_names so
+    two sources with the same ref_name never collide in the timeseries store.
+    """
+    try:
+        source_id = app.state.manager.register_datasource(req.source_id)
+        return {"ok": True, "source_id": source_id}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @app.post("/insert_timeseries")
 def insert_timeseries(streams: Annotated[list[StreamInsert], Body()]) -> dict[str, Any]:
     """Insert timeseries data for one or more streams.
@@ -249,6 +264,7 @@ def insert_timeseries(streams: Annotated[list[StreamInsert], Body()]) -> dict[st
         total = 0
         for s in streams:
             total += app.state.manager.insert_timeseries(
+                source_id=s.source_id,
                 ref_name=s.ref_name,
                 rows=s.values,
                 point_uri=s.point_uri,

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -4,9 +4,9 @@ import asyncio
 import io
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, Optional, Iterator
+from typing import Annotated, Any, Optional, Iterator
 
-from fastapi import FastAPI, HTTPException, Request, UploadFile, File, Form
+from fastapi import Body, FastAPI, HTTPException, Request, UploadFile, File, Form
 from fastapi.responses import StreamingResponse, Response
 from dateutil import parser as dtparser
 from pydantic import BaseModel, Field
@@ -23,8 +23,7 @@ from acquirium.internals.models import (
     AppSpec,
     AppRunRequest,
     AppStopRequest,
-    InsertTimeseriesRequest,
-    InsertBatchRequest,
+    StreamInsert,
 )
 from acquirium.internals.internals_namespaces import PLANT_URI
 
@@ -238,36 +237,23 @@ def list_app_runs(app_id: Optional[str] = None) -> dict[str, Any]:
 
 
 @app.post("/insert_timeseries")
-def insert_timeseries(
-    ref_uri: str,
-    req: InsertTimeseriesRequest,
-    point_uri: Optional[str] = None,
-    replace: bool = False,
-) -> dict[str, Any]:
-    try:
-        rows = req.values
-        n = app.state.manager.insert_timeseries(
-            ref_uri=ref_uri,
-            rows=rows,
-            point_uri=point_uri,
-            replace=replace,
-        )
-        return {"ok": True, "rows_inserted": n}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+def insert_timeseries(streams: Annotated[list[StreamInsert], Body()]) -> dict[str, Any]:
+    """Insert timeseries data for one or more streams.
 
-
-@app.post("/insert_timeseries_batch")
-def insert_timeseries_batch(req: InsertBatchRequest) -> dict[str, Any]:
-    """Insert timeseries data for multiple streams in a single request.
-
-    The request body is a JSON object mapping each point URI to a list of
-    ``[timestamp, value]`` pairs.
+    Each element specifies a ``ref_uri``, an optional ``point_uri`` (defaults
+    to ``ref_uri``), an optional ``replace`` flag, and a list of
+    ``[timestamp, value]`` pairs.  A single-stream insert is just a
+    one-element list.
     """
     try:
         total = 0
-        for point_uri, rows in req.streams.items():
-            total += app.state.manager.insert_timeseries(ref_uri=point_uri, rows=rows)
+        for s in streams:
+            total += app.state.manager.insert_timeseries(
+                ref_uri=s.ref_uri,
+                rows=s.values,
+                point_uri=s.point_uri,
+                replace=s.replace,
+            )
         return {"ok": True, "rows_inserted": total}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -249,7 +249,7 @@ def insert_timeseries(streams: Annotated[list[StreamInsert], Body()]) -> dict[st
         total = 0
         for s in streams:
             total += app.state.manager.insert_timeseries(
-                ref_uri=s.ref_uri,
+                ref_name=s.ref_name,
                 rows=s.values,
                 point_uri=s.point_uri,
                 replace=s.replace,

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -257,6 +257,8 @@ def register_datasource(req: RegisterDatasourceRequest) -> dict[str, Any]:
     try:
         source_id = app.state.manager.register_datasource(req.source_id)
         return {"ok": True, "source_id": source_id}
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -10,7 +10,7 @@ from rdflib import Graph, URIRef, Node, Literal, RDF, RDFS
 
 from acquirium.Storage import OxigraphGraphStore, TimescaleStore, PGReferenceRegistry, PGReferenceInfo, resolve_dsn
 from acquirium.internals.qudt_units import QUDTUnitConverter
-from acquirium.internals.models import LogEntry, TimeIntervalModel, AppSpec, AppRunRequest, compute_handle
+from acquirium.internals.models import LogEntry, Order, TimeIntervalModel, AppSpec, AppRunRequest, compute_handle
 from acquirium.internals.internals_namespaces import *
 from acquirium.internals.app_utils import app_uri_for, make_stream_ref_uri
 
@@ -740,10 +740,10 @@ class Manager:
     def timeseries_batch(
         self,
         uri: str,
-        start: str | None = None,
-        end: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
         limit: int | None = None,
-        order: str = "asc",
+        order: Order = "asc",
         batch_size: int = 50_000,
     ) :
         """
@@ -966,7 +966,7 @@ class Manager:
             "command": pick("cmd"),
         }
 
-    def _run_app_once(self, req: AppRunRequest, *, keep_alive: bool = False, interval: float | None = None) -> str:
+    def _run_app_once(self, req: AppRunRequest, *, keep_alive: bool = False, interval: float | None = None) -> str | None :
         if self._docker is None:
             raise ValueError("Docker is not available - cannot run apps")
 
@@ -1056,16 +1056,22 @@ class Manager:
             raise ValueError(f"Failed to run app {req.app_id}: {e}") from e
 
         cid = container.id
-        logger.info("Started docker container for app %s: %s", req.app_id, cid[:12])
+        if isinstance(cid,str):
+            logger.info("Started docker container for app %s: %s", req.app_id, cid[:12])
+        else: 
+            logger.warning("Container ID is not a string for app %s: %s", req.app_id, cid)
         return cid
 
-    def run_app(self, req: AppRunRequest) -> str:
+    def run_app(self, req: AppRunRequest) -> str | None:
         if not req.keep_alive:
             return self._run_app_once(req)
 
         cid = self._run_app_once(req, keep_alive=True, interval=req.interval)
         with self._app_runs_lock:
-            self._app_runs[cid] = {"app_id": req.app_id, "cid": cid}
+            if isinstance(cid, str):
+                self._app_runs[cid] = {"app_id": req.app_id, "cid": cid}
+            else:
+                logger.warning("Received non-string container ID for app %s: %s", req.app_id, cid)
         return cid
 
     def _stop_container(self, cid: str) -> None:
@@ -1243,7 +1249,7 @@ class Manager:
             obs_time_interval=obs_time_interval
         )
 
-    def delete_logs(self, point_uri: str) -> None:
+    def delete_logs(self, point_uri: str) -> bool:
         """
         Delete all log entries for a given point URI.
 

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -867,9 +867,9 @@ class Manager:
     ) -> int:
         handle = compute_handle(source_id, ref_name)
         if replace:
-            n = self.timescale.replace_rows(handle, rows)
+            n = self.timescale.replace_rows(str(handle), rows)
         else:
-            n = self.timescale.upsert_rows(handle, rows)
+            n = self.timescale.upsert_rows(str(handle), rows)
         if point_uri:
             self.timescale.ensure_stream_handle(point_uri, source_id, ref_name, handle=handle)
         return n

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -723,8 +723,9 @@ class Manager:
                 order=order,
                 batch_size=batch_size,
             )
+        storage_key = self.timescale.resolve_storage_key(uri)
         return self.timescale.timeseries(
-            point_uri=uri,
+            point_uri=storage_key,
             start=start,
             end=end,
             limit=limit,
@@ -741,7 +742,11 @@ class Manager:
         if pg_uris:
             result.update(self.pg_registry.timeseries_info_batch(pg_uris))
         if ts_uris:
-            result.update(self.timescale.timeseries_info_batch(ts_uris))
+            # Resolve each URI to its storage key (handle) before querying.
+            # Returns a dict keyed by storage_key; remap back to the original URI.
+            key_to_uri = {self.timescale.resolve_storage_key(u): u for u in ts_uris}
+            raw = self.timescale.timeseries_info_batch(list(key_to_uri.keys()))
+            result.update({key_to_uri[k]: v for k, v in raw.items()})
         return result
 
     def register_datasource(self, source_id: str) -> str:

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -856,7 +856,6 @@ class Manager:
         (app_dir / "app.json").write_text(json.dumps(meta, ensure_ascii=True, sort_keys=True))
 
         self.graph_store.insert_graph(graph, format="turtle", replace=False)
-        self._sync_stream_handles_from_graph()
 
     def _lookup_app_runtime(self, app_id: str) -> dict[str, str | None]:
         app_uri = app_uri_for(app_id)

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -42,6 +42,50 @@ def _wipe_dir_contents(base: Path) -> None:
         else:
             p.unlink()
 
+
+def _resolve_column(columns: list[str], identifier: str | None, default_index: int) -> str:
+    """Resolve a ref:timeColumnID / ref:valueColumnID literal to an actual column.
+
+    Tries the literal as a column name first. If it parses as an int and is
+    not present as a name, falls back to a positional index. Allows older
+    fixtures that hard-coded numeric column indices to keep working.
+    """
+    if identifier is None or identifier == "":
+        if default_index >= len(columns):
+            raise ValueError(f"File has only {len(columns)} columns; default index {default_index} out of range")
+        return columns[default_index]
+    if identifier in columns:
+        return identifier
+    try:
+        idx = int(identifier)
+    except ValueError as exc:
+        raise ValueError(f"Column {identifier!r} not found in file (columns={columns!r})") from exc
+    if idx < 0 or idx >= len(columns):
+        raise ValueError(f"Column index {idx} out of range (file has {len(columns)} columns)")
+    return columns[idx]
+
+
+def _parse_mqtt_broker(raw: str) -> tuple[str, int]:
+    """Split a ref:MQTTBroker literal into (host, port).
+
+    Accepts ``"host"``, ``"host:port"``, or ``"mqtt(s)://host[:port]"``.
+    Defaults to port 1883 (8883 for ``mqtts://``) when no port is given.
+    """
+    s = raw.strip()
+    default_port = 1883
+    if "://" in s:
+        scheme, _, rest = s.partition("://")
+        if scheme.lower() == "mqtts":
+            default_port = 8883
+        s = rest.split("/", 1)[0]
+    if ":" in s:
+        host, _, port_str = s.rpartition(":")
+        try:
+            return host or "localhost", int(port_str)
+        except ValueError:
+            return s, default_port
+    return s or "localhost", default_port
+
 @dataclass
 class Manager:
     timescale: TimescaleStore
@@ -216,18 +260,22 @@ class Manager:
 
     def _connect_mqtt_streams_from_graph(self) -> int:
         """
-        Scan graph for MQTTReference nodes attached to data nodes by hasExternalReference
-        and start background subscribers.
+        Scan graph for ref:MQTTReference nodes attached to data nodes by
+        ref:hasExternalReference and start background subscribers.
+
+        Per ref-schema.ttl, ref:MQTTBroker is a single string that may be
+        ``"host"``, ``"host:port"``, or a ``mqtt(s)://...`` URI; the port is
+        parsed out here rather than carried as a separate predicate.
+
         Returns number of subscriptions ensured.
         """
         q = f"""
-        SELECT ?data ?ref ?broker ?port ?topic ?tkey ?vkey
+        SELECT ?data ?ref ?broker ?topic ?tkey ?vkey
         WHERE {{
           ?data <{HAS_EXTERNAL_REFERENCE}> ?ref .
           ?ref a <{MQTT_REFERENCE}> .
-          OPTIONAL {{ ?ref <{BROKER}> ?broker . }}
-          OPTIONAL {{ ?ref <{PORT}> ?port . }}
-          OPTIONAL {{ ?ref <{TOPIC}> ?topic . }}
+          OPTIONAL {{ ?ref <{MQTT_BROKER}> ?broker . }}
+          OPTIONAL {{ ?ref <{MQTT_TOPIC}> ?topic . }}
           OPTIONAL {{ ?ref <{TIME_KEY}> ?tkey . }}
           OPTIONAL {{ ?ref <{VALUE_KEY}> ?vkey . }}
         }}
@@ -236,20 +284,21 @@ class Manager:
         rows = res.get("rows", [])
 
         count = 0
-        for data_uri, ref_uri, broker, port, topic, tkey, vkey in rows:
-            logger.info("Found MQTT reference: %s %s %s %s %s %s %s",
-                        data_uri, ref_uri, broker, port, topic, tkey, vkey)
-            broker_s = (broker or "localhost").strip('"')
-            port_s = (port or "1883").strip('"')
+        for data_uri, ref_uri, broker, topic, tkey, vkey in rows:
+            logger.info("Found MQTT reference: %s %s broker=%s topic=%s tkey=%s vkey=%s",
+                        data_uri, ref_uri, broker, topic, tkey, vkey)
+            broker_raw = (broker or "localhost").strip('"')
             topic_s = (topic or "").strip('"')
             if not topic_s:
                 continue
 
+            host, port_s = _parse_mqtt_broker(broker_raw)
+
             spec = MQTTStreamSpec(
                 point_uri=str(data_uri),
                 ref_uri=str(ref_uri),
-                broker=broker_s,
-                port=int(port_s),
+                broker=host,
+                port=port_s,
                 topic=topic_s,
                 time_key=(tkey or "Timestamp").strip('"'),
                 value_key=(vkey or "Value").strip('"'),
@@ -260,23 +309,28 @@ class Manager:
         return count
 
     def _scan_pg_references_from_graph(self) -> int:
-        """Scan graph for PGReference nodes and register them in the registry."""
+        """Scan graph for external Postgres timeseries references.
+
+        ref:TimeseriesReference is dual-purpose: Acquirium-managed streams use
+        it with ``acq:sourceId``/``acq:refName`` (handled by
+        ``_sync_stream_handles_from_graph``); external Postgres historians use
+        it with ``ref:storedAt`` as a literal DSN. We disambiguate by
+        requiring storedAt to be a Literal that begins with ``postgresql://``
+        or ``postgres://``.
+        """
         q = f"""
-        SELECT ?data ?ref ?dsn ?host ?port ?db ?user ?pass ?table ?query ?tcol ?vcol ?pfilter
+        SELECT ?data ?ref ?dsn ?table ?query ?tcol ?vcol ?pfilter
         WHERE {{
           ?data <{HAS_EXTERNAL_REFERENCE}> ?ref .
-          ?ref a <{PG_REFERENCE}> .
-          OPTIONAL {{ ?ref <{PG_DSN}> ?dsn . }}
-          OPTIONAL {{ ?ref <{PG_HOST}> ?host . }}
-          OPTIONAL {{ ?ref <{PG_PORT}> ?port . }}
-          OPTIONAL {{ ?ref <{PG_DB}> ?db . }}
-          OPTIONAL {{ ?ref <{PG_USER}> ?user . }}
-          OPTIONAL {{ ?ref <{PG_PASS}> ?pass . }}
-          OPTIONAL {{ ?ref <{PG_TABLE}> ?table . }}
-          OPTIONAL {{ ?ref <{PG_QUERY}> ?query . }}
-          OPTIONAL {{ ?ref <{PG_TIME_COL}> ?tcol . }}
-          OPTIONAL {{ ?ref <{PG_VALUE_COL}> ?vcol . }}
-          OPTIONAL {{ ?ref <{PG_POINT_FILTER}> ?pfilter . }}
+          ?ref a <{TIMESERIES_REFERENCE}> .
+          ?ref <{STORED_AT}> ?dsn .
+          FILTER(isLiteral(?dsn))
+          FILTER(STRSTARTS(STR(?dsn), "postgresql://") || STRSTARTS(STR(?dsn), "postgres://"))
+          OPTIONAL {{ ?ref <{TIMESERIES_TABLE}> ?table . }}
+          OPTIONAL {{ ?ref <{TIMESERIES_QUERY}> ?query . }}
+          OPTIONAL {{ ?ref <{TIMESERIES_TIME_COLUMN}> ?tcol . }}
+          OPTIONAL {{ ?ref <{TIMESERIES_VALUE_COLUMN}> ?vcol . }}
+          OPTIONAL {{ ?ref <{TIMESERIES_POINT_FILTER}> ?pfilter . }}
         }}
         """
         res = self.graph_store.sparql_query(q, use_union=True)
@@ -284,16 +338,11 @@ class Manager:
 
         count = 0
         for row in rows:
-            (data_uri, ref_uri, dsn, host, port, db, user, passwd,
-             table, custom_query, tcol, vcol, pfilter) = row
+            (data_uri, ref_uri, dsn, table, custom_query, tcol, vcol, pfilter) = row
             try:
                 s = lambda v: str(v).strip().strip('"') if v else None
-                resolved = resolve_dsn(
-                    dsn=s(dsn), host=s(host), port=s(port),
-                    db=s(db), user=s(user), password=s(passwd),
-                )
                 info = PGReferenceInfo(
-                    dsn=resolved,
+                    dsn=s(dsn) or "",
                     table=s(table),
                     custom_query=s(custom_query),
                     time_col=s(tcol) or "time",
@@ -303,22 +352,24 @@ class Manager:
                 self.pg_registry.register(str(ref_uri), info)
                 count += 1
             except Exception:
-                logger.warning("Failed to register PGReference %s", ref_uri, exc_info=True)
+                logger.warning("Failed to register external Postgres reference %s", ref_uri, exc_info=True)
 
         if count:
-            logger.info("Registered %d PGReference(s) from graph", count)
+            logger.info("Registered %d external Postgres reference(s) from graph", count)
         return count
 
     def _sync_stream_handles_from_graph(self) -> int:
-        """Scan the graph for Brick-style timeseries references and sync the streams handle table.
+        """Sync the streams handle table from Acquirium-managed timeseries refs.
 
-        Finds every pattern of the form:
+        Matches every pattern of the form:
             ?point  ref:hasExternalReference  ?ref_node .
             ?ref_node  a  ref:TimeseriesReference ;
-                       acquirium:sourceId  ?source_id ;
-                       acquirium:refName   ?ref_name .
+                       acq:sourceId  ?source_id ;
+                       acq:refName   ?ref_name .
         Recomputes the handle from (source_id, ref_name) and upserts into the
-        streams table.
+        streams table. External PG references (which have storedAt as a literal
+        DSN and no sourceId/refName) are skipped here and handled by
+        ``_scan_pg_references_from_graph``.
         """
         q = f"""
         SELECT ?point ?source_id ?ref_name
@@ -1125,12 +1176,20 @@ class Manager:
             *,
             data_uri: str,
             ref_uri: str,
-            ref_type: str,
             content: bytes,
-            time_column_no: int = 0,
-            value_column_no: int = 1,
+            time_column: str | None = None,
+            value_column: str | None = None,
             filename: str = "upload",
         ) -> int:
+        """Ingest the contents of a ref:FileReference upload into Timescale.
+
+        ``time_column`` / ``value_column`` are column identifiers as written
+        on the reference node (``ref:timeColumnID`` / ``ref:valueColumnID``).
+        Each is first tried as a column name; a numeric string falls back to
+        a positional index. ``time_column`` defaults to the first column,
+        ``value_column`` to the second. The file format (parquet vs csv) is
+        inferred from the ``filename`` extension.
+        """
         import polars as pl
         from io import BytesIO
         import time
@@ -1152,17 +1211,18 @@ class Manager:
 
         try:
             bio = BytesIO(content)
-
-            if ref_type == str(PARQUET_REF):
-                df = pl.read_parquet(bio, columns=[time_column_no, value_column_no])
-            elif ref_type == str(CSV_REF):
-                df = pl.read_csv(bio, columns=[time_column_no, value_column_no])
+            ext = Path(filename).suffix.lower()
+            if ext in {".parquet", ".pq"}:
+                full = pl.read_parquet(bio)
+            elif ext in {".csv", ".tsv", ".txt"}:
+                full = pl.read_csv(bio, separator="\t" if ext == ".tsv" else ",")
             else:
-                raise ValueError(f"Unsupported reference type: {ref_type}")
+                raise ValueError(f"Unsupported file extension for {filename!r}; expected parquet or csv/tsv")
 
-            # Rename selected columns to ts/value regardless of original names
-            if df.width != 2:
-                raise ValueError(f"Expected 2 columns after selection, got {df.width}")
+            cols = full.columns
+            t_col = _resolve_column(cols, time_column, default_index=0)
+            v_col = _resolve_column(cols, value_column, default_index=1)
+            df = full.select([t_col, v_col])
 
             df = df.rename({df.columns[0]: "ts", df.columns[1]: "value"})
 

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -306,28 +306,32 @@ class Manager:
         return count
 
     def _sync_stream_handles_from_graph(self) -> int:
-        """Scan the graph for point→ref pairs and populate the streams handle table.
+        """Scan the graph for Brick-style timeseries references and sync the streams handle table.
 
-        Finds every triple of the form:
-            ?point  acquirium:hasExternalReference  ?ref
-        where ?ref is typed as acquirium:TimeseriesStream, then calls
-        ensure_stream_handle so the streams table stays in sync with the graph.
+        Finds every pattern of the form:
+            ?point  ref:hasExternalReference  ?ref_node .
+            ?ref_node  a  ref:TimeseriesReference ;
+                       ref:hasTimeseriesId  ?ref_name .
+        and calls ensure_stream_handle(point_uri, ref_name) so the streams
+        table stays in sync with the graph.
         """
         q = f"""
-        SELECT ?point ?ref
+        SELECT ?point ?ref_name
         WHERE {{
-          ?point <{HAS_EXTERNAL_REFERENCE}> ?ref .
-          ?ref a <{TIMESERIES_STREAM}> .
+          ?point <{BRICK_REF_HAS_EXTERNAL_REFERENCE}> ?ref_node .
+          ?ref_node a <{BRICK_REF_TIMESERIES_REFERENCE}> .
+          ?ref_node <{BRICK_REF_HAS_TIMESERIES_ID}> ?ref_name .
         }}
         """
         res = self.graph_store.sparql_query(q, use_union=True)
         count = 0
-        for point_uri, ref_uri in res.get("rows", []):
+        for point_uri, ref_name in res.get("rows", []):
             try:
-                self.timescale.ensure_stream_handle(str(point_uri), str(ref_uri))
+                ref_name_str = str(ref_name).strip('"')
+                self.timescale.ensure_stream_handle(str(point_uri), ref_name_str)
                 count += 1
             except Exception:
-                logger.warning("Failed to ensure stream handle %s → %s", point_uri, ref_uri, exc_info=True)
+                logger.warning("Failed to ensure stream handle %s → %s", point_uri, ref_name, exc_info=True)
         if count:
             logger.info("Synced %d stream handle(s) from graph", count)
         return count
@@ -740,17 +744,17 @@ class Manager:
     def insert_timeseries(
         self,
         *,
-        ref_uri: str,
+        ref_name: str,
         rows: list[tuple[datetime, Any]],
         point_uri: str | None = None,
         replace: bool = False,
     ) -> int:
         if replace:
-            n = self.timescale.replace_rows(ref_uri, rows)
+            n = self.timescale.replace_rows(ref_name, rows)
         else:
-            n = self.timescale.upsert_rows(ref_uri, rows)
+            n = self.timescale.upsert_rows(ref_name, rows)
         if point_uri:
-            self.timescale.ensure_stream_handle(point_uri, ref_uri)
+            self.timescale.ensure_stream_handle(point_uri, ref_name)
         return n
 
     def _app_type_uri(self, app_type: str) -> URIRef:

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -10,7 +10,7 @@ from rdflib import Graph, URIRef, Node, Literal, RDF, RDFS
 
 from acquirium.Storage import OxigraphGraphStore, TimescaleStore, PGReferenceRegistry, PGReferenceInfo, resolve_dsn
 from acquirium.internals.qudt_units import QUDTUnitConverter
-from acquirium.internals.models import LogEntry, TimeIntervalModel, AppSpec, AppRunRequest
+from acquirium.internals.models import LogEntry, TimeIntervalModel, AppSpec, AppRunRequest, compute_handle
 from acquirium.internals.internals_namespaces import *
 from acquirium.internals.app_utils import app_uri_for, make_stream_ref_uri
 
@@ -311,27 +311,30 @@ class Manager:
         Finds every pattern of the form:
             ?point  ref:hasExternalReference  ?ref_node .
             ?ref_node  a  ref:TimeseriesReference ;
-                       ref:hasTimeseriesId  ?ref_name .
-        and calls ensure_stream_handle(point_uri, ref_name) so the streams
-        table stays in sync with the graph.
+                       acquirium:sourceId  ?source_id ;
+                       acquirium:refName   ?ref_name .
+        Recomputes the handle from (source_id, ref_name) and upserts into the
+        streams table.
         """
         q = f"""
-        SELECT ?point ?ref_name
+        SELECT ?point ?source_id ?ref_name
         WHERE {{
           ?point <{BRICK_REF_HAS_EXTERNAL_REFERENCE}> ?ref_node .
           ?ref_node a <{BRICK_REF_TIMESERIES_REFERENCE}> .
-          ?ref_node <{BRICK_REF_HAS_TIMESERIES_ID}> ?ref_name .
+          ?ref_node <{ACQUIRIUM_SOURCE_ID}> ?source_id .
+          ?ref_node <{ACQUIRIUM_REF_NAME}> ?ref_name .
         }}
         """
         res = self.graph_store.sparql_query(q, use_union=True)
         count = 0
-        for point_uri, ref_name in res.get("rows", []):
+        for point_uri, source_id, ref_name in res.get("rows", []):
             try:
-                ref_name_str = str(ref_name).strip('"')
-                self.timescale.ensure_stream_handle(str(point_uri), ref_name_str)
+                sid = str(source_id).strip('"')
+                rn  = str(ref_name).strip('"')
+                self.timescale.ensure_stream_handle(str(point_uri), sid, rn)
                 count += 1
             except Exception:
-                logger.warning("Failed to ensure stream handle %s → %s", point_uri, ref_name, exc_info=True)
+                logger.warning("Failed to ensure stream handle %s / %s → %s", point_uri, source_id, ref_name, exc_info=True)
         if count:
             logger.info("Synced %d stream handle(s) from graph", count)
         return count
@@ -741,20 +744,36 @@ class Manager:
             result.update(self.timescale.timeseries_info_batch(ts_uris))
         return result
 
+    def register_datasource(self, source_id: str) -> str:
+        """Register a named datasource in the knowledge graph.
+
+        Writes a graph node typed as acquirium:DataSourceRegistry so the
+        datasource is discoverable via SPARQL.  Idempotent — safe to call
+        on every startup.  Returns source_id.
+        """
+        g = Graph()
+        node = URIRef(f"urn:acquirium:datasource:{source_id}")
+        g.add((node, RDF.type,   ACQUIRIUM_DATASOURCE))
+        g.add((node, RDFS.label, Literal(source_id)))
+        self.graph_store.insert_graph(g, format="turtle", replace=False)
+        return source_id
+
     def insert_timeseries(
         self,
         *,
+        source_id: str,
         ref_name: str,
         rows: list[tuple[datetime, Any]],
         point_uri: str | None = None,
         replace: bool = False,
     ) -> int:
+        handle = compute_handle(source_id, ref_name)
         if replace:
-            n = self.timescale.replace_rows(ref_name, rows)
+            n = self.timescale.replace_rows(handle, rows)
         else:
-            n = self.timescale.upsert_rows(ref_name, rows)
+            n = self.timescale.upsert_rows(handle, rows)
         if point_uri:
-            self.timescale.ensure_stream_handle(point_uri, ref_name)
+            self.timescale.ensure_stream_handle(point_uri, source_id, ref_name)
         return n
 
     def _app_type_uri(self, app_type: str) -> URIRef:

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -846,11 +846,23 @@ class Manager:
         """Register a named datasource in the knowledge graph.
 
         Writes a graph node typed as acquirium:DataSourceRegistry so the
-        datasource is discoverable via SPARQL.  Idempotent — safe to call
-        on every startup.  Returns source_id.
+        datasource is discoverable via SPARQL.  Returns source_id.
+
+        Raises ``ValueError`` if a datasource with the same source_id is
+        already registered.
         """
-        g = Graph()
         node = URIRef(f"urn:acquirium:datasource:{source_id}")
+
+        check_query = f"""
+        ASK {{
+            <{node}> a <{ACQUIRIUM_DATASOURCE}> .
+        }}
+        """
+        exists = self.graph_store.sparql_query(check_query, use_union=True).get("boolean", False)
+        if exists:
+            raise ValueError(f"datasource '{source_id}' is already registered")
+
+        g = Graph()
         g.add((node, RDF.type,   ACQUIRIUM_DATASOURCE))
         g.add((node, RDFS.label, Literal(source_id)))
         self.graph_store.insert_graph(g, format="turtle", replace=False)

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import os
 import logging
 from time import perf_counter
-from rdflib import Graph, URIRef, Node, Literal, RDF, RDFS
+from rdflib import Graph, URIRef, Node, Literal, RDF, RDFS, SKOS
 
 from acquirium.Storage import OxigraphGraphStore, TimescaleStore, PGReferenceRegistry, PGReferenceInfo, resolve_dsn
 from acquirium.internals.qudt_units import QUDTUnitConverter
@@ -323,8 +323,8 @@ class Manager:
         q = f"""
         SELECT ?point ?source_id ?ref_name
         WHERE {{
-          ?point <{BRICK_REF_HAS_EXTERNAL_REFERENCE}> ?ref_node .
-          ?ref_node a <{BRICK_REF_TIMESERIES_REFERENCE}> .
+          ?point <{HAS_EXTERNAL_REFERENCE}> ?ref_node .
+          ?ref_node a <{TIMESERIES_REFERENCE}> .
           ?ref_node <{ACQUIRIUM_SOURCE_ID}> ?source_id .
           ?ref_node <{ACQUIRIUM_REF_NAME}> ?ref_name .
         }}
@@ -372,39 +372,39 @@ class Manager:
         # NOTE: QUDT Unit/QuantityKind removed — handled by _qudt_matcher
         # Labels: rdfs:label, skos:prefLabel, skos:altLabel
         # Language filter: keep English-tagged or untagged labels only
-        class_query = """
-        SELECT DISTINCT ?uri ?label WHERE {
-          {
-            ?uri a <http://www.w3.org/2000/01/rdf-schema#Class> .
-          } UNION {
-            ?uri a <http://www.w3.org/2002/07/owl#Class> .
-          } UNION {
-            ?x <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?uri .
-          } UNION {
+        class_query = f"""
+        SELECT DISTINCT ?uri ?label WHERE {{
+          {{
+            ?uri a <{RDFS.Class}> .
+          }} UNION {{
+            ?uri a <{OWL_CLASS}> .
+          }} UNION {{
+            ?x <{RDFS.subClassOf}> ?uri .
+          }} UNION {{
             ?x a ?uri .
-          } UNION {
-            ?uri a <urn:nawi-water-ontology#Class> .
-          } UNION {
-            ?uri <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?x .
-          } UNION {
-            ?x <http://qudt.org/schema/qudt/hasEnumerationKind> ?uri .
-          } UNION {
-            ?x <http://data.ashrae.org/standard223#ofSubstance> ?uri .
-          } UNION {
-            ?x <http://data.ashrae.org/standard223#hasMedium> ?uri .
-          }
-          OPTIONAL {
-            {
-              ?uri <http://www.w3.org/2000/01/rdf-schema#label> ?label .
-            } UNION {
-              ?uri <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
-            } UNION {
-              ?uri <http://www.w3.org/2004/02/skos/core#altLabel> ?label .
-            }
+          }} UNION {{
+            ?uri a <{WATR.Class}> .
+          }} UNION {{
+            ?uri <{RDFS.subClassOf}> ?x .
+          }} UNION {{
+            ?x <{HAS_ENUMERATION_KIND}> ?uri .
+          }} UNION {{
+            ?x <{OF_SUBSTANCE}> ?uri .
+          }} UNION {{
+            ?x <{HAS_MEDIUM}> ?uri .
+          }}
+          OPTIONAL {{
+            {{
+              ?uri <{RDFS.label}> ?label .
+            }} UNION {{
+              ?uri <{SKOS.prefLabel}> ?label .
+            }} UNION {{
+              ?uri <{SKOS.altLabel}> ?label .
+            }}
             FILTER(LANG(?label) = "" || LANGMATCHES(LANG(?label), "en"))
-          }
+          }}
           FILTER(isIRI(?uri))
-        }
+        }}
         """
         try:
             res = self.graph_store.sparql_query(class_query, use_union=True)
@@ -450,29 +450,29 @@ class Manager:
         # Query 2: Predicates (declared properties + any IRI used as a predicate)
         # Labels: rdfs:label, skos:prefLabel, skos:altLabel
         # Language filter: keep English-tagged or untagged labels only
-        pred_query = """
-        SELECT DISTINCT ?uri ?label WHERE {
-          {
-            ?uri a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
-          } UNION {
-            ?uri a <http://www.w3.org/2002/07/owl#ObjectProperty> .
-          } UNION {
-            ?uri a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
-          } UNION {
+        pred_query = f"""
+        SELECT DISTINCT ?uri ?label WHERE {{
+          {{
+            ?uri a <{RDF_PROP}> .
+          }} UNION {{
+            ?uri a <{OWL_OBJ_PROP}> .
+          }} UNION {{
+            ?uri a <{OWL_DATA_PROP}> .
+          }} UNION {{
             ?s ?uri ?o .
-          }
-          OPTIONAL {
-            {
-              ?uri <http://www.w3.org/2000/01/rdf-schema#label> ?label .
-            } UNION {
-              ?uri <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
-            } UNION {
-              ?uri <http://www.w3.org/2004/02/skos/core#altLabel> ?label .
-            }
+          }}
+          OPTIONAL {{
+            {{
+              ?uri <{RDFS.label}> ?label .
+            }} UNION {{
+              ?uri <{SKOS.prefLabel}> ?label .
+            }} UNION {{
+              ?uri <{SKOS.altLabel}> ?label .
+            }}
             FILTER(LANG(?label) = "" || LANGMATCHES(LANG(?label), "en"))
-          }
+          }}
           FILTER(isIRI(?uri))
-        }
+        }}
         """
         try:
             res = self.graph_store.sparql_query(pred_query, use_union=True)

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -856,6 +856,7 @@ class Manager:
         (app_dir / "app.json").write_text(json.dumps(meta, ensure_ascii=True, sort_keys=True))
 
         self.graph_store.insert_graph(graph, format="turtle", replace=False)
+        self._sync_stream_handles_from_graph()
 
     def _lookup_app_runtime(self, app_id: str) -> dict[str, str | None]:
         app_uri = app_uri_for(app_id)

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -12,7 +12,7 @@ from acquirium.Storage import OxigraphGraphStore, TimescaleStore, PGReferenceReg
 from acquirium.internals.qudt_units import QUDTUnitConverter
 from acquirium.internals.models import LogEntry, Order, TimeIntervalModel, AppSpec, AppRunRequest, compute_handle
 from acquirium.internals.internals_namespaces import *
-from acquirium.internals.app_utils import app_uri_for, make_stream_ref_uri
+from acquirium.internals.app_utils import app_uri_for
 
 import json
 import hashlib
@@ -846,22 +846,10 @@ class Manager:
         """Register a named datasource in the knowledge graph.
 
         Writes a graph node typed as acquirium:DataSourceRegistry so the
-        datasource is discoverable via SPARQL.  Returns source_id.
-
-        Raises ``ValueError`` if a datasource with the same source_id is
-        already registered.
+        datasource is discoverable via SPARQL.  Idempotent — safe to call
+        on every startup.  Returns source_id.
         """
         node = URIRef(f"urn:acquirium:datasource:{source_id}")
-
-        check_query = f"""
-        ASK {{
-            <{node}> a <{ACQUIRIUM_DATASOURCE}> .
-        }}
-        """
-        exists = self.graph_store.sparql_query(check_query, use_union=True).get("boolean", False)
-        if exists:
-            raise ValueError(f"datasource '{source_id}' is already registered")
-
         g = Graph()
         g.add((node, RDF.type,   ACQUIRIUM_DATASOURCE))
         g.add((node, RDFS.label, Literal(source_id)))
@@ -955,18 +943,18 @@ class Manager:
 
         for out in spec.outputs:
             point_uri = URIRef(out.point_uri)
-            ref_uri = URIRef(out.ref_uri or make_stream_ref_uri(out.point_uri))
+            handle = compute_handle(spec.name, out.point_uri)
 
             graph.add((app_uri, PRODUCES, point_uri))
             graph.add((point_uri, RDF.type, VIRTUAL_POINT))
-            graph.add((point_uri, HAS_EXTERNAL_REFERENCE, ref_uri))
-            graph.add((ref_uri, RDF.type, STREAM))
+            graph.add((point_uri, HAS_EXTERNAL_REFERENCE, handle))
+            graph.add((handle, RDF.type, STREAM))
             if out.kind in {"event", "trigger"}:
-                graph.add((ref_uri, RDF.type, EVENT_STREAM))
+                graph.add((handle, RDF.type, EVENT_STREAM))
             else:
-                graph.add((ref_uri, RDF.type, TIMESERIES_STREAM))
+                graph.add((handle, RDF.type, TIMESERIES_STREAM))
 
-            graph.add((ref_uri, STORAGE_BACKEND, Literal(out.storage_backend or "timescale")))
+            graph.add((handle, STORAGE_BACKEND, Literal(out.storage_backend or "timescale")))
 
             self._add_literal_or_uri(graph, point_uri, HAS_QUANTITY_KIND, out.quantity_kind)
             self._add_literal_or_uri(graph, point_uri, HAS_UNIT, out.unit)

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -742,9 +742,10 @@ class Manager:
         if pg_uris:
             result.update(self.pg_registry.timeseries_info_batch(pg_uris))
         if ts_uris:
-            # Resolve each URI to its storage key (handle) before querying.
-            # Returns a dict keyed by storage_key; remap back to the original URI.
-            key_to_uri = {self.timescale.resolve_storage_key(u): u for u in ts_uris}
+            # Resolve URIs to storage keys (handles) in one batch query, then
+            # remap results back to the original URIs.
+            uri_to_key = self.timescale.resolve_storage_keys(ts_uris)
+            key_to_uri = {v: k for k, v in uri_to_key.items()}
             raw = self.timescale.timeseries_info_batch(list(key_to_uri.keys()))
             result.update({key_to_uri[k]: v for k, v in raw.items()})
         return result
@@ -778,7 +779,7 @@ class Manager:
         else:
             n = self.timescale.upsert_rows(handle, rows)
         if point_uri:
-            self.timescale.ensure_stream_handle(point_uri, source_id, ref_name)
+            self.timescale.ensure_stream_handle(point_uri, source_id, ref_name, handle=handle)
         return n
 
     def _app_type_uri(self, app_type: str) -> URIRef:

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -305,6 +305,33 @@ class Manager:
             logger.info("Registered %d PGReference(s) from graph", count)
         return count
 
+    def _sync_stream_handles_from_graph(self) -> int:
+        """Scan the graph for point→ref pairs and populate the streams handle table.
+
+        Finds every triple of the form:
+            ?point  acquirium:hasExternalReference  ?ref
+        where ?ref is typed as acquirium:TimeseriesStream, then calls
+        ensure_stream_handle so the streams table stays in sync with the graph.
+        """
+        q = f"""
+        SELECT ?point ?ref
+        WHERE {{
+          ?point <{HAS_EXTERNAL_REFERENCE}> ?ref .
+          ?ref a <{TIMESERIES_STREAM}> .
+        }}
+        """
+        res = self.graph_store.sparql_query(q, use_union=True)
+        count = 0
+        for point_uri, ref_uri in res.get("rows", []):
+            try:
+                self.timescale.ensure_stream_handle(str(point_uri), str(ref_uri))
+                count += 1
+            except Exception:
+                logger.warning("Failed to ensure stream handle %s → %s", point_uri, ref_uri, exc_info=True)
+        if count:
+            logger.info("Synced %d stream handle(s) from graph", count)
+        return count
+
     def _save_ingest_cache(self, cache: dict[str, Any]) -> None:
         tmp = self._ingest_cache_path.with_suffix(".tmp")
         tmp.write_text(json.dumps(cache, indent=2, sort_keys=True, default=str))
@@ -649,6 +676,7 @@ class Manager:
             logging.info("acquirium: inserted graph into store, now ingesting data")
             self._connect_mqtt_streams_from_graph()
             self._scan_pg_references_from_graph()
+            self._sync_stream_handles_from_graph()
 
             if wait_for_embedding:
                 logger.info("acquirium: rebuilding embedding index (synchronous)...")

--- a/src/acquirium/Server/mqtt_ingestion.py
+++ b/src/acquirium/Server/mqtt_ingestion.py
@@ -218,7 +218,6 @@ class MQTTIngestService:
                         for ref_uri, samples in pending.items():
                             for sample in samples:
                                 rows = [(sample.ts, sample.value)]
-                                ts_store.ensure_stream_handle(sample.point_uri, ref_uri)
                                 ts_store.upsert_rows(ref_uri, rows)
                 except Exception as exc:
                     logger.error("mqtt db flush failed err=%s", exc)
@@ -231,7 +230,6 @@ class MQTTIngestService:
                     for ref_uri, samples in pending.items():
                         for sample in samples:
                             rows = [(sample.ts, sample.value)]
-                            ts_store.ensure_stream_handle(sample.point_uri, ref_uri)
                             ts_store.upsert_rows(ref_uri, rows)
             except Exception:
                 logger.error("mqtt db final flush failed")

--- a/src/acquirium/Storage/timescale_store.py
+++ b/src/acquirium/Storage/timescale_store.py
@@ -81,7 +81,7 @@ class TimescaleStore(TimeseriesStore):
                 CREATE TABLE IF NOT EXISTS {STREAMS_TABLE} (
                     handle TEXT PRIMARY KEY,
                     point_uri TEXT UNIQUE NOT NULL,
-                    ref_uri TEXT NOT NULL
+                    ref_name TEXT NOT NULL
                 );
                 """
             )
@@ -165,27 +165,33 @@ class TimescaleStore(TimeseriesStore):
             return -1
 
     # -------------------- stream handles --------------------
-    def ensure_stream_handle(self, point_uri, ref_uri: str, handle: str | None = None) -> str:
+    def ensure_stream_handle(self, point_uri: str, ref_name: str, handle: str | None = None) -> str:
+        """Register a point_uri → ref_name mapping and return its short handle.
+
+        ``ref_name`` is the identifier used by the original data source
+        (e.g. a sensor tag, MQTT topic, database column, or timeseries ID).
+        It is stored as-is and used as the TimescaleDB storage key.
+        """
         if handle is None:
-            handle = hashlib.sha1(ref_uri.encode("utf-8")).hexdigest()[:10]
+            handle = hashlib.sha1(ref_name.encode("utf-8")).hexdigest()[:10]
         with self.conn.cursor() as cur:
             cur.execute(
                 f"""
-                INSERT INTO {STREAMS_TABLE} (handle, point_uri, ref_uri)
+                INSERT INTO {STREAMS_TABLE} (handle, point_uri, ref_name)
                 VALUES (%s, %s, %s)
-                ON CONFLICT (point_uri) DO UPDATE SET handle = EXCLUDED.handle
+                ON CONFLICT (point_uri) DO UPDATE SET handle = EXCLUDED.handle, ref_name = EXCLUDED.ref_name
                 """,
-                (handle, point_uri, ref_uri),
+                (handle, point_uri, ref_name),
             )
         return handle
 
-    def resolve_handle(self, handle: str) -> str:
-        '''
-        Resolves a stream handle to its corresponding point URI and ref URI.
-        Returns a tuple of (point_uri, ref_uri) or (None, None) if not found.
-        '''
+    def resolve_handle(self, handle: str) -> tuple[str | None, str | None]:
+        """Resolve a short handle to its (point_uri, ref_name) pair.
+
+        Returns (None, None) if the handle is not found.
+        """
         with self.conn.cursor() as cur:
-            cur.execute(f"SELECT point_uri, ref_uri FROM {STREAMS_TABLE} WHERE handle = %s", (handle,))
+            cur.execute(f"SELECT point_uri, ref_name FROM {STREAMS_TABLE} WHERE handle = %s", (handle,))
             row = cur.fetchone()
             return (row[0], row[1]) if row else (None, None)
 

--- a/src/acquirium/Storage/timescale_store.py
+++ b/src/acquirium/Storage/timescale_store.py
@@ -10,7 +10,7 @@ import psycopg
 from psycopg import sql
 from psycopg.types.json import Json
 
-from acquirium.internals.models import Order, TimeseriesInfo, TimeInterval, LogEntry, TimeIntervalModel
+from acquirium.internals.models import Order, TimeseriesInfo, TimeInterval, LogEntry, TimeIntervalModel, compute_handle
 from acquirium.Storage.base import TimeseriesStore
 import logging
 import pyarrow as pa
@@ -81,6 +81,7 @@ class TimescaleStore(TimeseriesStore):
                 CREATE TABLE IF NOT EXISTS {STREAMS_TABLE} (
                     handle TEXT PRIMARY KEY,
                     point_uri TEXT UNIQUE NOT NULL,
+                    source_id TEXT NOT NULL,
                     ref_name TEXT NOT NULL
                 );
                 """
@@ -165,35 +166,43 @@ class TimescaleStore(TimeseriesStore):
             return -1
 
     # -------------------- stream handles --------------------
-    def ensure_stream_handle(self, point_uri: str, ref_name: str, handle: str | None = None) -> str:
-        """Register a point_uri → ref_name mapping and return its short handle.
+    def ensure_stream_handle(self, point_uri: str, source_id: str, ref_name: str) -> str:
+        """Register a (point_uri, source_id, ref_name) mapping in the streams table.
 
-        ``ref_name`` is the identifier used by the original data source
-        (e.g. a sensor tag, MQTT topic, database column, or timeseries ID).
-        It is stored as-is and used as the TimescaleDB storage key.
+        The handle is computed deterministically from (source_id, ref_name) via
+        :func:`compute_handle`, so two sources with the same ref_name never
+        produce the same storage key.  The handle is also used as the
+        TimescaleDB row key for the stream's data.
+
+        Returns the handle.
         """
-        if handle is None:
-            handle = hashlib.sha1(ref_name.encode("utf-8")).hexdigest()[:10]
+        handle = compute_handle(source_id, ref_name)
         with self.conn.cursor() as cur:
             cur.execute(
                 f"""
-                INSERT INTO {STREAMS_TABLE} (handle, point_uri, ref_name)
-                VALUES (%s, %s, %s)
-                ON CONFLICT (point_uri) DO UPDATE SET handle = EXCLUDED.handle, ref_name = EXCLUDED.ref_name
+                INSERT INTO {STREAMS_TABLE} (handle, point_uri, source_id, ref_name)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (point_uri) DO UPDATE
+                    SET handle = EXCLUDED.handle,
+                        source_id = EXCLUDED.source_id,
+                        ref_name = EXCLUDED.ref_name
                 """,
-                (handle, point_uri, ref_name),
+                (handle, point_uri, source_id, ref_name),
             )
         return handle
 
-    def resolve_handle(self, handle: str) -> tuple[str | None, str | None]:
-        """Resolve a short handle to its (point_uri, ref_name) pair.
+    def resolve_handle(self, handle: str) -> tuple[str | None, str | None, str | None]:
+        """Resolve a handle to its (point_uri, source_id, ref_name) triple.
 
-        Returns (None, None) if the handle is not found.
+        Returns (None, None, None) if the handle is not found.
         """
         with self.conn.cursor() as cur:
-            cur.execute(f"SELECT point_uri, ref_name FROM {STREAMS_TABLE} WHERE handle = %s", (handle,))
+            cur.execute(
+                f"SELECT point_uri, source_id, ref_name FROM {STREAMS_TABLE} WHERE handle = %s",
+                (handle,),
+            )
             row = cur.fetchone()
-            return (row[0], row[1]) if row else (None, None)
+            return (row[0], row[1], row[2]) if row else (None, None, None)
 
     # -------------------- queries --------------------
     def timeseries(

--- a/src/acquirium/Storage/timescale_store.py
+++ b/src/acquirium/Storage/timescale_store.py
@@ -15,7 +15,7 @@ from acquirium.Storage.base import TimeseriesStore
 import logging
 import pyarrow as pa
 import polars as pl
-
+from rdflib import URIRef
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ class TimescaleStore(TimeseriesStore):
                 f"""
                 CREATE TABLE IF NOT EXISTS {STREAMS_TABLE} (
                     handle TEXT PRIMARY KEY,
-                    point_uri TEXT UNIQUE NOT NULL,
+                    point_uri TEXT NOT NULL,
                     source_id TEXT NOT NULL,
                     ref_name TEXT NOT NULL
                 );
@@ -170,7 +170,7 @@ class TimescaleStore(TimeseriesStore):
             return -1
 
     # -------------------- stream handles --------------------
-    def ensure_stream_handle(self, point_uri: str, source_id: str, ref_name: str, handle: str | None = None) -> str:
+    def ensure_stream_handle(self, point_uri: str, source_id: str, ref_name: str, handle: URIRef | None = None) -> URIRef:
         """Register a (point_uri, source_id, ref_name) mapping in the streams table.
 
         The handle is computed deterministically from (source_id, ref_name) via
@@ -188,16 +188,17 @@ class TimescaleStore(TimeseriesStore):
                 f"""
                 INSERT INTO {STREAMS_TABLE} (handle, point_uri, source_id, ref_name)
                 VALUES (%s, %s, %s, %s)
-                ON CONFLICT (point_uri) DO UPDATE
-                    SET handle = EXCLUDED.handle,
+                ON CONFLICT (handle) DO UPDATE
+                    SET 
+                        point_uri = EXCLUDED.point_uri,
                         source_id = EXCLUDED.source_id,
                         ref_name = EXCLUDED.ref_name
                 """,
-                (handle, point_uri, source_id, ref_name),
+                (str(handle), point_uri, source_id, ref_name),
             )
         return handle
 
-    def resolve_handle(self, handle: str) -> tuple[str | None, str | None, str | None]:
+    def resolve_handle(self, handle: URIRef) -> tuple[str | None, str | None, str | None]:
         """Resolve a handle to its (point_uri, source_id, ref_name) triple.
 
         Returns (None, None, None) if the handle is not found.
@@ -205,7 +206,7 @@ class TimescaleStore(TimeseriesStore):
         with self.conn.cursor() as cur:
             cur.execute(
                 f"SELECT point_uri, source_id, ref_name FROM {STREAMS_TABLE} WHERE handle = %s",
-                (handle,),
+                (str(handle),),
             )
             row = cur.fetchone()
             return (row[0], row[1], row[2]) if row else (None, None, None)

--- a/src/acquirium/Storage/timescale_store.py
+++ b/src/acquirium/Storage/timescale_store.py
@@ -73,7 +73,7 @@ class TimescaleStore(TimeseriesStore):
                 f"ALTER TABLE {TIMESERIES_TABLE} SET (timescaledb.compress, timescaledb.compress_segmentby = 'point_uri', timescaledb.compress_orderby = 'ts');"
             )
             cur.execute(
-                "SELECT add_compression_policy('timeseries', INTERVAL '7 days');"
+                "SELECT add_compression_policy('timeseries', INTERVAL '7 days', if_not_exists => TRUE);"
             )
 
             # add unique constraint on (point_uri, ts) pairs

--- a/src/acquirium/Storage/timescale_store.py
+++ b/src/acquirium/Storage/timescale_store.py
@@ -72,6 +72,10 @@ class TimescaleStore(TimeseriesStore):
             cur.execute(
                 f"ALTER TABLE {TIMESERIES_TABLE} SET (timescaledb.compress, timescaledb.compress_segmentby = 'point_uri', timescaledb.compress_orderby = 'ts');"
             )
+            cur.execute(
+                "SELECT add_compression_policy('timeseries', INTERVAL '7 days');"
+            )
+
             # add unique constraint on (point_uri, ts) pairs
             cur.execute(
                 f"CREATE UNIQUE INDEX IF NOT EXISTS idx_timeseries_point_ts_unique ON {TIMESERIES_TABLE} (point_uri, ts);"
@@ -166,17 +170,19 @@ class TimescaleStore(TimeseriesStore):
             return -1
 
     # -------------------- stream handles --------------------
-    def ensure_stream_handle(self, point_uri: str, source_id: str, ref_name: str) -> str:
+    def ensure_stream_handle(self, point_uri: str, source_id: str, ref_name: str, handle: str | None = None) -> str:
         """Register a (point_uri, source_id, ref_name) mapping in the streams table.
 
         The handle is computed deterministically from (source_id, ref_name) via
         :func:`compute_handle`, so two sources with the same ref_name never
         produce the same storage key.  The handle is also used as the
-        TimescaleDB row key for the stream's data.
+        TimescaleDB row key for the stream's data.  Pass a precomputed handle
+        to avoid recomputing it when already available.
 
         Returns the handle.
         """
-        handle = compute_handle(source_id, ref_name)
+        if handle is None:
+            handle = compute_handle(source_id, ref_name)
         with self.conn.cursor() as cur:
             cur.execute(
                 f"""
@@ -218,6 +224,23 @@ class TimescaleStore(TimeseriesStore):
             )
             row = cur.fetchone()
             return row[0] if row else point_uri
+
+    def resolve_storage_keys(self, point_uris: list[str]) -> dict[str, str]:
+        """Batch-resolve point_uris to storage keys in a single query.
+
+        Returns a mapping of point_uri → handle (or point_uri itself for
+        unregistered URIs, preserving the single-URI fallback behaviour).
+        """
+        if not point_uris:
+            return {}
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT point_uri, handle FROM {STREAMS_TABLE} WHERE point_uri = ANY(%s)",
+                (point_uris,),
+            )
+            rows = cur.fetchall()
+        registered = {row[0]: row[1] for row in rows}
+        return {uri: registered.get(uri, uri) for uri in point_uris}
 
     # -------------------- queries --------------------
     def timeseries(

--- a/src/acquirium/Storage/timescale_store.py
+++ b/src/acquirium/Storage/timescale_store.py
@@ -204,6 +204,21 @@ class TimescaleStore(TimeseriesStore):
             row = cur.fetchone()
             return (row[0], row[1], row[2]) if row else (None, None, None)
 
+    def resolve_storage_key(self, point_uri: str) -> str:
+        """Return the storage key (handle) for a point_uri, or point_uri itself if not registered.
+
+        Streams inserted via insert_timeseries are stored under their handle (UUID).
+        This resolves the semantic URI → handle so reads find the right rows.
+        Falls back to the URI itself for data inserted directly (e.g. bulk CSV ingest).
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT handle FROM {STREAMS_TABLE} WHERE point_uri = %s",
+                (point_uri,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else point_uri
+
     # -------------------- queries --------------------
     def timeseries(
         self,

--- a/src/acquirium/TextMatch/qudt_store.py
+++ b/src/acquirium/TextMatch/qudt_store.py
@@ -13,21 +13,8 @@ import logging
 import re
 from pathlib import Path
 from typing import Any
-
+from acquirium.internals.internals_namespaces import *
 logger = logging.getLogger("acquirium.qudt_store")
-
-# RDF predicates we care about
-_RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
-_RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-_QUDT_UNIT = "http://qudt.org/schema/qudt/Unit"
-_QUDT_QK = "http://qudt.org/schema/qudt/QuantityKind"
-_QUDT_SYMBOL = "http://qudt.org/schema/qudt/symbol"
-_QUDT_UCUM = "http://qudt.org/schema/qudt/ucumCode"
-
-# HTTP sources
-_UNIT_HTTP = "http://qudt.org/vocab/unit"
-_QK_HTTP = "http://qudt.org/vocab/quantitykind"
-
 
 def _split_local_name(uri: str) -> list[str]:
     """Split a URI local name on CamelCase, underscores, hyphens into lowercase tokens."""
@@ -90,10 +77,6 @@ class QUDTStore:
         from rdflib import Graph, URIRef, Namespace
         from rdflib.namespace import SKOS
 
-        QUDT = Namespace("http://qudt.org/schema/qudt/")
-        RDFS = Namespace("http://www.w3.org/2000/01/rdf-schema#")
-        RDF = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
-
         g = Graph()
         loaded = False
 
@@ -150,7 +133,7 @@ class QUDTStore:
             if not surfaces:
                 continue
 
-            kind = "unit" if rdf_type == _QUDT_UNIT else "quantity_kind"
+            kind = "unit" if rdf_type == str(QUDT.Unit) else "quantity_kind"
             concepts.append({
                 "uri": uri,
                 "kind": kind,
@@ -206,8 +189,8 @@ class QUDTStore:
             local_qk_path = Path("ontologies/qudt_qk.ttl")
 
         # Parse fresh
-        units = self._parse_ontology(_UNIT_HTTP, local_unit_path, _QUDT_UNIT)
-        qks = self._parse_ontology(_QK_HTTP, local_qk_path, _QUDT_QK)
+        units = self._parse_ontology(str(QUDT_UNIT), local_unit_path, str(QUDT.Unit))
+        qks = self._parse_ontology(str(QUDT_QUANTITY_KIND), local_qk_path, str(QUDT.QuantityKind))
         fresh_concepts = units + qks
         fresh_uris = {c["uri"] for c in fresh_concepts}
 

--- a/src/acquirium/internals/app_utils.py
+++ b/src/acquirium/internals/app_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 from urllib.parse import quote
 
 from acquirium.internals.internals_namespaces import ACQUIRIUM_NS
@@ -12,8 +11,3 @@ def _safe_fragment(value: str) -> str:
 
 def app_uri_for(name: str) -> str:
     return str(ACQUIRIUM_NS[f"app/{_safe_fragment(name)}"])
-
-
-def make_stream_ref_uri(point_uri: str) -> str:
-    digest = hashlib.sha1(point_uri.encode("utf-8")).hexdigest()[:12]
-    return str(ACQUIRIUM_NS[f"stream/{digest}"])

--- a/src/acquirium/internals/internals_namespaces.py
+++ b/src/acquirium/internals/internals_namespaces.py
@@ -57,14 +57,19 @@ LAST_RUN = ACQUIRIUM_NS.lastRun
 LAST_INPUT_CHANGE = ACQUIRIUM_NS.lastInputChange
 
 
-# Acquirium-internal external reference (used for MQTT, CSV, PG sources)
+# External-reference vocabulary follows ontologies/ref-schema.ttl
+# (https://brickschema.org/schema/Brick/ref#). Predicates that the schema
+# does not define live under ACQUIRIUM_NS and are Acquirium-specific.
 HAS_EXTERNAL_REFERENCE = BRICK_REF.hasExternalReference
+EXTERNAL_REFERENCE = BRICK_REF.ExternalReference
 TIMESERIES_REFERENCE = BRICK_REF.TimeseriesReference
 HAS_TIMESERIES_ID = BRICK_REF.hasTimeseriesId
 STORED_AT = BRICK_REF.storedAt
 
 
-# Predicates stored on Brick ref nodes to allow handle reconstruction from graph
+# Predicates stored on TimeseriesReference nodes to distinguish
+# Acquirium-managed streams (these two are present) from external PG
+# references (storedAt is a literal DSN).
 ACQUIRIUM_SOURCE_ID  = ACQUIRIUM_NS.sourceId   # the registered datasource name
 ACQUIRIUM_REF_NAME   = ACQUIRIUM_NS.refName    # the source-local stream identifier
 
@@ -82,35 +87,35 @@ LOGBOOK = ACQUIRIUM_NS.Logbook
 PLANT_URI = str(ACQUIRIUM_NS.Plant)  # Generic URI representing the entire plant
 
 
-# File-based Reference predicates
-PARQUET_REF = ACQUIRIUM_NS.ParquetReference
-CSV_REF = BRICK_REF.csvReference
-CSV_LOCATION = BRICK_REF.csvFileLocation
-REF_PATH = ACQUIRIUM_NS.hasFilePath
-REF_TIME_COL = ACQUIRIUM_NS.hasTimeColumn
-REF_VALUE_COL = ACQUIRIUM_NS.hasValueColumn
+# Origin tag literal on a reference node (e.g. "Lab", "SCADA").
+DATA_SOURCE = ACQUIRIUM_NS.dataSource
 
-# MQTT Reference predicates
-MQTT_REFERENCE = ACQUIRIUM_NS.MQTTReference
-BROKER = ACQUIRIUM_NS.mqttBroker
-PORT = ACQUIRIUM_NS.mqttPort
-TOPIC = ACQUIRIUM_NS.mqttTopic
-VALUE_KEY = ACQUIRIUM_NS.mqttValueKey
-TIME_KEY = ACQUIRIUM_NS.mqttTimeKey
+# Tabular file references (parquet/csv/tsv). File type is inferred from
+# the fileLocation extension; ref:csvReference is intentionally not used.
+FILE_REFERENCE = BRICK_REF.FileReference
+HAS_FILE_REFERENCE = BRICK_REF.hasFileReference
+FILE_LOCATION = BRICK_REF.fileLocation
+TIME_COLUMN_ID = BRICK_REF.timeColumnID
+VALUE_COLUMN_ID = BRICK_REF.valueColumnID
 
-# Postgres Reference predicates
-PG_REFERENCE = TIMESERIES_REFERENCE
-PG_DSN = ACQUIRIUM_NS.postgresDSN
-PG_HOST = ACQUIRIUM_NS.postgresHost
-PG_PORT = ACQUIRIUM_NS.postgresPort
-PG_DB = ACQUIRIUM_NS.postgresDB
-PG_USER = ACQUIRIUM_NS.postgresUser
-PG_PASS = ACQUIRIUM_NS.postgresPass
-PG_TABLE = ACQUIRIUM_NS.postgresTable
-PG_QUERY = ACQUIRIUM_NS.postgresQuery
-PG_TIME_COL = ACQUIRIUM_NS.postgresTimeColumn
-PG_VALUE_COL = ACQUIRIUM_NS.postgresValueColumn
-PG_POINT_FILTER = ACQUIRIUM_NS.postgresPointFilter
+# MQTT Reference predicates. timeKey/valueKey are Acquirium-specific (they
+# describe how to decode a JSON payload) and live under ACQUIRIUM_NS.
+MQTT_REFERENCE = BRICK_REF.MQTTReference
+HAS_MQTT_REFERENCE = BRICK_REF.hasMQTTReference
+MQTT_BROKER = BRICK_REF.MQTTBroker  # accepts "host", "host:port", or "mqtt(s)://..."
+MQTT_TOPIC = BRICK_REF.MQTTTopic
+TIME_KEY = ACQUIRIUM_NS.timeKey
+VALUE_KEY = ACQUIRIUM_NS.valueKey
+
+# External Postgres / generic-DSN timeseries.  These reuse ref:TimeseriesReference
+# and ref:storedAt (with storedAt as a literal DSN) but the column/table/query
+# predicates are Acquirium-specific.
+HAS_TIMESERIES_REFERENCE = BRICK_REF.hasTimeseriesReference
+TIMESERIES_TABLE        = ACQUIRIUM_NS.timeseriesTable
+TIMESERIES_QUERY        = ACQUIRIUM_NS.timeseriesQuery
+TIMESERIES_TIME_COLUMN  = ACQUIRIUM_NS.timeseriesTimeColumn
+TIMESERIES_VALUE_COLUMN = ACQUIRIUM_NS.timeseriesValueColumn
+TIMESERIES_POINT_FILTER = ACQUIRIUM_NS.timeseriesPointFilter
 
 OWL_CLASS = URIRef("http://www.w3.org/2002/07/owl#Class")
 OWL_OBJ_PROP = URIRef("http://www.w3.org/2002/07/owl#ObjectProperty")

--- a/src/acquirium/internals/internals_namespaces.py
+++ b/src/acquirium/internals/internals_namespaces.py
@@ -11,6 +11,7 @@ UNIT = Namespace("http://qudt.org/vocab/unit/")
 S223 = Namespace("http://data.ashrae.org/standard223#")
 WATR = Namespace("urn:nawi-water-ontology#")
 BRICK = Namespace("https://brickschema.org/schema/Brick#")
+BRICK_REF = Namespace("https://brickschema.org/schema/Brick/ref#")
 OWL = Namespace("http://www.w3.org/2002/07/owl#")
 
 
@@ -50,7 +51,19 @@ LAST_RUN = ACQUIRIUM_NS.lastRun
 LAST_INPUT_CHANGE = ACQUIRIUM_NS.lastInputChange
 
 
+# Acquirium-internal external reference (used for MQTT, CSV, PG sources)
 HAS_EXTERNAL_REFERENCE = ACQUIRIUM_NS.hasExternalReference
+
+# Brick ref vocabulary — used for timeseries database linkage
+BRICK_REF_HAS_EXTERNAL_REFERENCE = BRICK_REF.hasExternalReference
+BRICK_REF_TIMESERIES_REFERENCE = BRICK_REF.TimeseriesReference
+BRICK_REF_HAS_TIMESERIES_ID = BRICK_REF.hasTimeseriesId
+BRICK_REF_STORED_AT = BRICK_REF.storedAt
+BRICK_REF_DATABASE = BRICK_REF.Database
+
+# Well-known URI representing the Acquirium TimescaleDB instance
+ACQUIRIUM_DB_URI = URIRef("urn:acquirium:timescaledb")
+
 HAS_MEDIUM = S223.hasMedium
 OF_SUBSTANCE = S223.ofSubstance
 HAS_QUANTITY_KIND = QUDT.hasQuantityKind

--- a/src/acquirium/internals/internals_namespaces.py
+++ b/src/acquirium/internals/internals_namespaces.py
@@ -64,6 +64,13 @@ BRICK_REF_DATABASE = BRICK_REF.Database
 # Well-known URI representing the Acquirium TimescaleDB instance
 ACQUIRIUM_DB_URI = URIRef("urn:acquirium:timescaledb")
 
+# Predicates stored on Brick ref nodes to allow handle reconstruction from graph
+ACQUIRIUM_SOURCE_ID  = ACQUIRIUM_NS.sourceId   # the registered datasource name
+ACQUIRIUM_REF_NAME   = ACQUIRIUM_NS.refName    # the source-local stream identifier
+
+# Class for registered datasource nodes
+ACQUIRIUM_DATASOURCE = ACQUIRIUM_NS.DataSourceRegistry
+
 HAS_MEDIUM = S223.hasMedium
 OF_SUBSTANCE = S223.ofSubstance
 HAS_QUANTITY_KIND = QUDT.hasQuantityKind

--- a/src/acquirium/internals/internals_namespaces.py
+++ b/src/acquirium/internals/internals_namespaces.py
@@ -1,9 +1,11 @@
 from rdflib.namespace import Namespace
 from rdflib import URIRef, RDF, RDFS
 
+### ACQUIRIUM INTERNAL NAMESPACES
 ACQUIRIUM_NS = Namespace("urn:acquirium#")
 ACQUIRIUM_POINT_NS = Namespace("urn:acquirium:point#")
 
+### External Namespaces
 QUDT = Namespace("http://qudt.org/schema/qudt/")
 QUDT_UNIT = Namespace("http://qudt.org/vocab/unit/")
 QUDT_QUANTITY_KIND = Namespace("http://qudt.org/vocab/quantitykind/")
@@ -19,6 +21,11 @@ OWL = Namespace("http://www.w3.org/2002/07/owl#")
 DEFAULT_MAIN_GRAPH = ACQUIRIUM_NS.MainGraph
 DEFAULT_UNION_GRAPH = ACQUIRIUM_NS.UnionGraph
 VIRTUAL_POINT = ACQUIRIUM_NS.VirtualPoint
+
+# Well-known URI representing the Acquirium TimescaleDB instance
+ACQUIRIUM_DB_URI = ACQUIRIUM_NS.TimescaleDB
+DATABASE = ACQUIRIUM_NS.Database
+
 
 LAST_REPORTED = ACQUIRIUM_NS.lastReported
 IS_CALCULATED_FROM = ACQUIRIUM_NS.isCalculatedFrom
@@ -38,7 +45,6 @@ ALARM = ACQUIRIUM_NS.Alarm
 REPORT = ACQUIRIUM_NS.Report
 
 # Soft sensor SHACL-ish vocabulary
-# SS = Namespace("urn:duckttape:ss#")
 SOFT_SENSOR = ACQUIRIUM_NS.SoftSensor
 STREAM = ACQUIRIUM_NS.Stream
 DATA_SOURCE = ACQUIRIUM_NS.DataSource
@@ -52,17 +58,11 @@ LAST_INPUT_CHANGE = ACQUIRIUM_NS.lastInputChange
 
 
 # Acquirium-internal external reference (used for MQTT, CSV, PG sources)
-HAS_EXTERNAL_REFERENCE = ACQUIRIUM_NS.hasExternalReference
+HAS_EXTERNAL_REFERENCE = BRICK_REF.hasExternalReference
+TIMESERIES_REFERENCE = BRICK_REF.TimeseriesReference
+HAS_TIMESERIES_ID = BRICK_REF.hasTimeseriesId
+STORED_AT = BRICK_REF.storedAt
 
-# Brick ref vocabulary — used for timeseries database linkage
-BRICK_REF_HAS_EXTERNAL_REFERENCE = BRICK_REF.hasExternalReference
-BRICK_REF_TIMESERIES_REFERENCE = BRICK_REF.TimeseriesReference
-BRICK_REF_HAS_TIMESERIES_ID = BRICK_REF.hasTimeseriesId
-BRICK_REF_STORED_AT = BRICK_REF.storedAt
-BRICK_REF_DATABASE = BRICK_REF.Database
-
-# Well-known URI representing the Acquirium TimescaleDB instance
-ACQUIRIUM_DB_URI = URIRef("urn:acquirium:timescaledb")
 
 # Predicates stored on Brick ref nodes to allow handle reconstruction from graph
 ACQUIRIUM_SOURCE_ID  = ACQUIRIUM_NS.sourceId   # the registered datasource name
@@ -76,7 +76,6 @@ OF_SUBSTANCE = S223.ofSubstance
 HAS_QUANTITY_KIND = QUDT.hasQuantityKind
 HAS_ENUMERATION_KIND = QUDT.hasEnumerationKind
 HAS_UNIT = QUDT.hasUnit
-DATA_SOURCE = ACQUIRIUM_NS.DataSource
 
 HAS_LOG = ACQUIRIUM_NS.hasLog
 LOGBOOK = ACQUIRIUM_NS.Logbook
@@ -85,32 +84,33 @@ PLANT_URI = str(ACQUIRIUM_NS.Plant)  # Generic URI representing the entire plant
 
 # File-based Reference predicates
 PARQUET_REF = ACQUIRIUM_NS.ParquetReference
-CSV_REF = ACQUIRIUM_NS.CSVReference
+CSV_REF = BRICK_REF.csvReference
+CSV_LOCATION = BRICK_REF.csvFileLocation
 REF_PATH = ACQUIRIUM_NS.hasFilePath
 REF_TIME_COL = ACQUIRIUM_NS.hasTimeColumn
 REF_VALUE_COL = ACQUIRIUM_NS.hasValueColumn
 
 # MQTT Reference predicates
-BROKER = ACQUIRIUM_NS.Broker
-PORT = ACQUIRIUM_NS.Port
-TOPIC = ACQUIRIUM_NS.Topic
-VALUE_KEY = ACQUIRIUM_NS.value_key
-TIME_KEY = ACQUIRIUM_NS.time_key
 MQTT_REFERENCE = ACQUIRIUM_NS.MQTTReference
+BROKER = ACQUIRIUM_NS.mqttBroker
+PORT = ACQUIRIUM_NS.mqttPort
+TOPIC = ACQUIRIUM_NS.mqttTopic
+VALUE_KEY = ACQUIRIUM_NS.mqttValueKey
+TIME_KEY = ACQUIRIUM_NS.mqttTimeKey
 
 # Postgres Reference predicates
-PG_REFERENCE = ACQUIRIUM_NS.PGReference
-PG_DSN = ACQUIRIUM_NS.PG_DSN
-PG_HOST = ACQUIRIUM_NS.PG_HOST
-PG_PORT = ACQUIRIUM_NS.PG_PORT
-PG_DB = ACQUIRIUM_NS.PG_DB
-PG_USER = ACQUIRIUM_NS.PG_USER
-PG_PASS = ACQUIRIUM_NS.PG_PASS
-PG_TABLE = ACQUIRIUM_NS.PG_Table
-PG_QUERY = ACQUIRIUM_NS.PG_Query
-PG_TIME_COL = ACQUIRIUM_NS.PG_TimeColumn
-PG_VALUE_COL = ACQUIRIUM_NS.PG_ValueColumn
-PG_POINT_FILTER = ACQUIRIUM_NS.PG_PointFilter
+PG_REFERENCE = TIMESERIES_REFERENCE
+PG_DSN = ACQUIRIUM_NS.postgresDSN
+PG_HOST = ACQUIRIUM_NS.postgresHost
+PG_PORT = ACQUIRIUM_NS.postgresPort
+PG_DB = ACQUIRIUM_NS.postgresDB
+PG_USER = ACQUIRIUM_NS.postgresUser
+PG_PASS = ACQUIRIUM_NS.postgresPass
+PG_TABLE = ACQUIRIUM_NS.postgresTable
+PG_QUERY = ACQUIRIUM_NS.postgresQuery
+PG_TIME_COL = ACQUIRIUM_NS.postgresTimeColumn
+PG_VALUE_COL = ACQUIRIUM_NS.postgresValueColumn
+PG_POINT_FILTER = ACQUIRIUM_NS.postgresPointFilter
 
 OWL_CLASS = URIRef("http://www.w3.org/2002/07/owl#Class")
 OWL_OBJ_PROP = URIRef("http://www.w3.org/2002/07/owl#ObjectProperty")

--- a/src/acquirium/internals/models.py
+++ b/src/acquirium/internals/models.py
@@ -34,16 +34,13 @@ class PointCreateRequest(BaseModel):
     unit: str | None = None
 
 
-class InsertTimeseriesRequest(BaseModel):
+class StreamInsert(BaseModel):
+    """A single stream's data payload, used in the unified insert endpoint."""
+
+    ref_uri: str
+    point_uri: str | None = None
+    replace: bool = False
     values: list[tuple[datetime, float | int | str | None]]
-
-
-class InsertBatchRequest(RootModel[dict[str, list[tuple[datetime, float | int | str | None]]]]):
-    """Batch insert where keys are point URIs and values are lists of (ts, value)."""
-
-    @property
-    def streams(self) -> dict[str, list[tuple[datetime, float | int | str]]]:
-        return self.root
 
 
 Order = Literal["asc", "desc"]

--- a/src/acquirium/internals/models.py
+++ b/src/acquirium/internals/models.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Literal, Any, TYPE_CHECKING
 from dataclasses import dataclass
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 from acquirium.internals.internals_namespaces import ACQUIRIUM_NS
 from rdflib import URIRef
 # Fixed UUID namespace for deterministic handle generation.
@@ -37,9 +37,11 @@ class TimeseriesInfo(BaseModel):
 
 
 class Point(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     uri: str
     handle: str | URIRef | list[str] | list[URIRef] | None = None
-    types: list[str] = Field(default_factory=list)  
+    types: list[str] = Field(default_factory=list)
     unit: str | None = None
     last_reported: datetime | None = None
     stream: TimeseriesInfo | None = None
@@ -151,7 +153,6 @@ class AppContext:
 class AppOutputSpec(BaseModel):
     kind: Literal["timeseries", "event", "trigger"]
     point_uri: str
-    ref_uri: str | None = None
     quantity_kind: str | None = None
     unit: str | None = None
     data_source: str | None = None

--- a/src/acquirium/internals/models.py
+++ b/src/acquirium/internals/models.py
@@ -2,11 +2,26 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+import uuid
+from datetime import datetime, timedelta
 from typing import Literal, Any, TYPE_CHECKING
 from dataclasses import dataclass
 from pydantic import BaseModel, Field, RootModel
-from datetime import timedelta
+
+# Fixed UUID namespace for deterministic handle generation.
+# All (source_id, ref_name) pairs are hashed within this namespace so handles
+# are globally unique and reproducible without any state.
+_HANDLE_NAMESPACE = uuid.UUID("6a8f3c2e-4b1d-5e7f-9012-3a4b5c6d7e8f")
+
+
+def compute_handle(source_id: str, ref_name: str) -> str:
+    """Return a deterministic UUID5 handle for a (source_id, ref_name) pair.
+
+    The handle is used as the TimescaleDB storage key and stored as
+    ``ref:hasTimeseriesId`` in the RDF graph.  It is stable across restarts
+    and can be recomputed at any time from the same inputs.
+    """
+    return str(uuid.uuid5(_HANDLE_NAMESPACE, f"{source_id}:{ref_name}"))
 
 if TYPE_CHECKING:
     from acquirium.Client.query import Query
@@ -34,14 +49,22 @@ class PointCreateRequest(BaseModel):
     unit: str | None = None
 
 
-class StreamInsert(BaseModel):
-    """A single stream's data payload, used in the unified insert endpoint.
+class RegisterDatasourceRequest(BaseModel):
+    """Request to register a named datasource."""
+    source_id: str
 
-    ``ref_name`` is the identifier used by the original data source (e.g. a
-    sensor tag, MQTT topic, or database column name).  It is used as the
-    storage key in TimescaleDB and recorded in the streams handle table.
+
+class StreamInsert(BaseModel):
+    """A single stream's data payload for the unified insert endpoint.
+
+    ``source_id`` identifies the registered datasource (e.g. ``"mybox-metrics"``).
+    ``ref_name`` is the source-local stream identifier (e.g. ``"cpu_percent"``).
+    The TimescaleDB storage key (handle) is computed deterministically from
+    both via :func:`compute_handle` — so two sources with the same ``ref_name``
+    never collide.
     """
 
+    source_id: str
     ref_name: str
     point_uri: str | None = None
     replace: bool = False

--- a/src/acquirium/internals/models.py
+++ b/src/acquirium/internals/models.py
@@ -35,9 +35,14 @@ class PointCreateRequest(BaseModel):
 
 
 class StreamInsert(BaseModel):
-    """A single stream's data payload, used in the unified insert endpoint."""
+    """A single stream's data payload, used in the unified insert endpoint.
 
-    ref_uri: str
+    ``ref_name`` is the identifier used by the original data source (e.g. a
+    sensor tag, MQTT topic, or database column name).  It is used as the
+    storage key in TimescaleDB and recorded in the streams handle table.
+    """
+
+    ref_name: str
     point_uri: str | None = None
     replace: bool = False
     values: list[tuple[datetime, float | int | str | None]]

--- a/src/acquirium/internals/models.py
+++ b/src/acquirium/internals/models.py
@@ -7,21 +7,23 @@ from datetime import datetime, timedelta
 from typing import Literal, Any, TYPE_CHECKING
 from dataclasses import dataclass
 from pydantic import BaseModel, Field, RootModel
-
+from acquirium.internals.internals_namespaces import ACQUIRIUM_NS
+from rdflib import URIRef
 # Fixed UUID namespace for deterministic handle generation.
 # All (source_id, ref_name) pairs are hashed within this namespace so handles
 # are globally unique and reproducible without any state.
 _HANDLE_NAMESPACE = uuid.UUID("6a8f3c2e-4b1d-5e7f-9012-3a4b5c6d7e8f")
 
 
-def compute_handle(source_id: str, ref_name: str) -> str:
+def compute_handle(source_id: str, ref_name: str) -> URIRef:
     """Return a deterministic UUID5 handle for a (source_id, ref_name) pair.
 
     The handle is used as the TimescaleDB storage key and stored as
     ``ref:hasTimeseriesId`` in the RDF graph.  It is stable across restarts
     and can be recomputed at any time from the same inputs.
     """
-    return str(uuid.uuid5(_HANDLE_NAMESPACE, f"{source_id}:{ref_name}"))
+    handle_str = str(uuid.uuid5(_HANDLE_NAMESPACE, f"{source_id}:{ref_name}"))
+    return ACQUIRIUM_NS[handle_str]
 
 if TYPE_CHECKING:
     from acquirium.Client.query import Query
@@ -36,8 +38,8 @@ class TimeseriesInfo(BaseModel):
 
 class Point(BaseModel):
     uri: str
-    handle: str | None = None
-    types: list[str] = Field(default_factory=list)
+    handle: str | URIRef | list[str] | list[URIRef] | None = None
+    types: list[str] = Field(default_factory=list)  
     unit: str | None = None
     last_reported: datetime | None = None
     stream: TimeseriesInfo | None = None

--- a/src/acquirium/internals/qudt_units.py
+++ b/src/acquirium/internals/qudt_units.py
@@ -29,11 +29,8 @@ from decimal import Decimal, getcontext
 from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import RDF, RDFS, SKOS, XSD
 
-from acquirium.internals.internals_namespaces import QUDT, UNIT
+from acquirium.internals.internals_namespaces import QUDT, UNIT, QUDT_QUANTITY_KIND
 
-# QUDT also defines a quantity kind vocabulary; we keep the namespace local to
-# avoid coupling other parts of the codebase to it.
-QUDT_QUANTITY_KIND_PROP = URIRef("http://qudt.org/schema/qudt/quantityKind")
 
 COMMON_ALIASES: dict[str, URIRef] = {
     "gallon": UNIT.GAL_US,
@@ -101,7 +98,7 @@ class UnitDefinition:
                     return lit
             return None
 
-        quantity_kinds = list(graph.objects(uri, QUDT_QUANTITY_KIND_PROP))
+        quantity_kinds = list(graph.objects(uri, QUDT.QuantityKind))
         quantity_kinds += list(graph.objects(uri, QUDT.hasQuantityKind))
         # Deduplicate while preserving order
         seen_qk: set[URIRef] = set()
@@ -112,7 +109,7 @@ class UnitDefinition:
                 unique_qks.append(qk)
 
         # Prefer the canonical Length quantity kind when multiple exist (common in QUDT dumps)
-        preferred = URIRef("http://qudt.org/vocab/quantitykind/Length")
+        preferred = QUDT_QUANTITY_KIND.Length
         if preferred in unique_qks:
             quantity_kind = preferred
         else:

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -119,7 +119,8 @@ class TestGraphEndpoints:
 
 
 class TestTimeseriesEndpoints:
-    TEST_REF = "urn:test:api_ts_ref"
+    TEST_SOURCE = "test"
+    TEST_REF_NAME = "api_ts_ref"
     TEST_POINT = "urn:test:api_ts_point"
 
     def _insert_data(self, n=5):
@@ -129,8 +130,13 @@ class TestTimeseriesEndpoints:
         ]
         resp = requests.post(
             f"{BASE_URL}/insert_timeseries",
-            params={"ref_uri": self.TEST_REF, "point_uri": self.TEST_POINT},
-            json={"values": values},
+            json=[{
+                "source_id": self.TEST_SOURCE,
+                "ref_name": self.TEST_REF_NAME,
+                "point_uri": self.TEST_POINT,
+                "replace": False,
+                "values": values,
+            }],
         )
         return resp
 
@@ -139,7 +145,7 @@ class TestTimeseriesEndpoints:
         assert resp.status_code == 200
 
         resp = requests.get(f"{BASE_URL}/timeseries", params={
-            "uri": self.TEST_REF,
+            "uri": self.TEST_POINT,
         })
         assert resp.status_code == 200
         # Response is Arrow IPC
@@ -175,12 +181,12 @@ class TestTimeseriesEndpoints:
     def test_timeseries_info(self):
         self._insert_data(3)
         resp = requests.post(f"{BASE_URL}/timeseries_info", json={
-            "uris": [self.TEST_REF],
+            "uris": [self.TEST_POINT],
         })
         assert resp.status_code == 200
         data = resp.json()
-        assert self.TEST_REF in data
-        assert data[self.TEST_REF]["row_count"] >= 3
+        assert self.TEST_POINT in data
+        assert data[self.TEST_POINT]["row_count"] >= 3
 
     def test_replace(self):
         self._insert_data(10)
@@ -189,8 +195,13 @@ class TestTimeseriesEndpoints:
         ]
         resp = requests.post(
             f"{BASE_URL}/insert_timeseries",
-            params={"ref_uri": self.TEST_REF, "point_uri": self.TEST_POINT, "replace": True},
-            json={"values": values},
+            json=[{
+                "source_id": self.TEST_SOURCE,
+                "ref_name": self.TEST_REF_NAME,
+                "point_uri": self.TEST_POINT,
+                "replace": True,
+                "values": values,
+            }],
         )
         assert resp.status_code == 200
 

--- a/tests/integration/test_timescale_store.py
+++ b/tests/integration/test_timescale_store.py
@@ -113,30 +113,37 @@ class TestBulkInsertPolars:
 
 
 class TestStreamHandles:
-    def test_auto_handle(self, ts_store, clean_point):
-        handle = ts_store.ensure_stream_handle(clean_point, TEST_REF)
+    TEST_SOURCE = "test_source"
+    TEST_REF_NAME = "test_ref"
+
+    def test_handle_is_uuid(self, ts_store, clean_point):
+        handle = ts_store.ensure_stream_handle(clean_point, self.TEST_SOURCE, self.TEST_REF_NAME)
         assert isinstance(handle, str)
-        assert len(handle) == 10
+        assert len(handle) == 36  # UUID5 string form
 
-    def test_custom_handle(self, ts_store, clean_point):
-        handle = ts_store.ensure_stream_handle(clean_point, TEST_REF, handle="custom123")
-        assert handle == "custom123"
-
-    def test_idempotent(self, ts_store, clean_point):
-        h1 = ts_store.ensure_stream_handle(clean_point, TEST_REF)
-        h2 = ts_store.ensure_stream_handle(clean_point, TEST_REF)
+    def test_deterministic(self, ts_store, clean_point):
+        # Same source_id + ref_name always yields the same handle.
+        h1 = ts_store.ensure_stream_handle(clean_point, self.TEST_SOURCE, self.TEST_REF_NAME)
+        h2 = ts_store.ensure_stream_handle(clean_point, self.TEST_SOURCE, self.TEST_REF_NAME)
         assert h1 == h2
 
+    def test_different_sources_different_handles(self, ts_store, clean_point):
+        h1 = ts_store.ensure_stream_handle(clean_point, "source_a", self.TEST_REF_NAME)
+        h2 = ts_store.ensure_stream_handle(clean_point, "source_b", self.TEST_REF_NAME)
+        assert h1 != h2
+
     def test_resolve_handle(self, ts_store, clean_point):
-        handle = ts_store.ensure_stream_handle(clean_point, TEST_REF)
-        point, ref = ts_store.resolve_handle(handle)
+        handle = ts_store.ensure_stream_handle(clean_point, self.TEST_SOURCE, self.TEST_REF_NAME)
+        point, source_id, ref_name = ts_store.resolve_handle(handle)
         assert point == clean_point
-        assert ref == TEST_REF
+        assert source_id == self.TEST_SOURCE
+        assert ref_name == self.TEST_REF_NAME
 
     def test_resolve_unknown_handle(self, ts_store):
-        point, ref = ts_store.resolve_handle("nonexistent_handle")
+        point, source_id, ref_name = ts_store.resolve_handle("nonexistent_handle")
         assert point is None
-        assert ref is None
+        assert source_id is None
+        assert ref_name is None
 
 
 # ── Query Tests ────────────────────────────────────────────

--- a/tests/integration/test_timescale_store.py
+++ b/tests/integration/test_timescale_store.py
@@ -11,7 +11,7 @@ import polars as pl
 
 from acquirium.Storage.timescale_store import TimescaleStore
 from acquirium.internals.models import LogEntry, TimeIntervalModel
-
+from rdflib import URIRef
 
 TEST_POINT = "urn:test:integration_point"
 TEST_REF = "urn:test:integration_ref"
@@ -118,8 +118,8 @@ class TestStreamHandles:
 
     def test_handle_is_uuid(self, ts_store, clean_point):
         handle = ts_store.ensure_stream_handle(clean_point, self.TEST_SOURCE, self.TEST_REF_NAME)
-        assert isinstance(handle, str)
-        assert len(handle) == 36  # UUID5 string form
+        assert isinstance(handle, URIRef)
+        assert len(handle) == len("urn:acquirium#") + 36  # UUID5 string form
 
     def test_deterministic(self, ts_store, clean_point):
         # Same source_id + ref_name always yields the same handle.

--- a/tests/src/graph_generator.py
+++ b/tests/src/graph_generator.py
@@ -26,6 +26,7 @@ def build_test_graph_csv() -> Graph:
     g = Graph()
     g.bind("ex", ex)
     g.bind("acq", ACQUIRIUM_NS)
+    g.bind("ref", BRICK_REF)
     g.bind("s223", S223)
     g.bind("qudt", QUDT)
 
@@ -104,13 +105,13 @@ def build_test_graph_csv() -> Graph:
             g.add((point, HAS_ENUMERATION_KIND, ACQUIRIUM_NS[f"EnumerationKind{1}"]))
         g.add((point, HAS_UNIT, ACQUIRIUM_NS[f"Unit{i//4}"]))
 
-        # CSV reference node
-        g.add((ref, RDF.type, ACQUIRIUM_NS.CSVReference))
+        # CSV reference node — ref:FileReference (file format inferred from extension)
+        g.add((ref, RDF.type, FILE_REFERENCE))
         g.add((ref, DATA_SOURCE, Literal("LAB")))
-        g.add((ref, REF_PATH, Literal(csv_path)))
-        g.add((ref, REF_TIME_COL, Literal(0)))
+        g.add((ref, FILE_LOCATION, Literal(csv_path)))
+        g.add((ref, TIME_COLUMN_ID, Literal("0")))
         # Value column: 1..10 (assumes time is col 0)
-        g.add((ref, REF_VALUE_COL, Literal(i)))
+        g.add((ref, VALUE_COLUMN_ID, Literal(str(i))))
 
     return g
 
@@ -122,6 +123,7 @@ def build_test_graph_stream() -> Graph:
     g = Graph()
     g.bind("ex", ex)
     g.bind("acq", ACQUIRIUM_NS)
+    g.bind("ref", BRICK_REF)
     g.bind("s223", S223)
     g.bind("qudt", QUDT)
 
@@ -164,14 +166,13 @@ def build_test_graph_stream() -> Graph:
         g.add((point, HAS_QUANTITY_KIND, ACQUIRIUM_NS[f"QuantityKind{i//2}"]))
         g.add((point, HAS_UNIT, ACQUIRIUM_NS[f"Unit{i}"]))
 
-        # CSV reference node
-        g.add((ref, RDF.type, ACQUIRIUM_NS.MQTTReference))
+        # MQTT reference node — port encoded in the broker literal per ref-schema
+        g.add((ref, RDF.type, MQTT_REFERENCE))
         g.add((ref, DATA_SOURCE, Literal("SCADA")))
-        g.add((ref, BROKER, Literal("mosquitto")))
-        g.add((ref, PORT, Literal("1883")))
+        g.add((ref, MQTT_BROKER, Literal("mosquitto:1883")))
+        g.add((ref, MQTT_TOPIC, Literal(f"topic{i-10}")))
         g.add((ref, TIME_KEY, Literal("Timestamp")))
         g.add((ref, VALUE_KEY, Literal("Value")))
-        g.add((ref, TOPIC, Literal(f"topic{i-10}")))
 
     return g
 

--- a/tests/test_model.ttl
+++ b/tests/test_model.ttl
@@ -1,15 +1,15 @@
 @prefix acq: <urn:acquirium#> .
 @prefix ex: <urn:ex/> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix s223: <http://data.ashrae.org/standard223#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:point_10 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasEnumerationKind acq:EnumerationKind1 ;
     qudt:hasUnit acq:Unit2 ;
-    acq:hasExternalReference ex:point_10_csv_ref .
+    ref:hasExternalReference ex:point_10_csv_ref .
 
 ex:eq_1 a acq:A ;
     acq:hasProperty ex:point_9 ;
@@ -35,176 +35,172 @@ ex:point_1 a acq:QuantifiableObservableProperty ;
     s223:ofSubstance acq:Substance1 ;
     qudt:hasQuantityKind acq:QuantityKind0 ;
     qudt:hasUnit acq:Unit0 ;
-    acq:hasExternalReference ex:point_1_csv_ref .
+    ref:hasExternalReference ex:point_1_csv_ref .
 
-ex:point_10_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 10 .
+ex:point_10_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "10" ;
+    acq:dataSource "LAB" .
 
 ex:point_11 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium3 ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind5 ;
     qudt:hasUnit acq:Unit11 ;
-    acq:hasExternalReference ex:point_11_mqtt_ref .
+    ref:hasExternalReference ex:point_11_mqtt_ref .
 
-ex:point_11_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic1" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_11_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic1" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 ex:point_12 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasQuantityKind acq:QuantityKind6 ;
     qudt:hasUnit acq:Unit12 ;
-    acq:hasExternalReference ex:point_12_mqtt_ref .
+    ref:hasExternalReference ex:point_12_mqtt_ref .
 
-ex:point_12_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic2" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_12_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic2" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 ex:point_13 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasQuantityKind acq:QuantityKind6 ;
     qudt:hasUnit acq:Unit13 ;
-    acq:hasExternalReference ex:point_13_mqtt_ref .
+    ref:hasExternalReference ex:point_13_mqtt_ref .
 
-ex:point_13_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic3" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_13_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic3" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 ex:point_14 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasQuantityKind acq:QuantityKind7 ;
     qudt:hasUnit acq:Unit14 ;
-    acq:hasExternalReference ex:point_14_mqtt_ref .
+    ref:hasExternalReference ex:point_14_mqtt_ref .
 
-ex:point_14_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic4" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_14_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic4" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
-ex:point_1_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+ex:point_1_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "1" ;
+    acq:dataSource "LAB" .
 
 ex:point_2 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium1 ;
     s223:ofSubstance acq:Substance1 ;
     qudt:hasQuantityKind acq:QuantityKind0 ;
     qudt:hasUnit acq:Unit0 ;
-    acq:hasExternalReference ex:point_2_csv_ref .
+    ref:hasExternalReference ex:point_2_csv_ref .
 
-ex:point_2_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 2 .
+ex:point_2_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "2" ;
+    acq:dataSource "LAB" .
 
 ex:point_3 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium2 ;
     s223:ofSubstance acq:Substance2 ;
     qudt:hasQuantityKind acq:QuantityKind1 ;
     qudt:hasUnit acq:Unit0 ;
-    acq:hasExternalReference ex:point_3_csv_ref .
+    ref:hasExternalReference ex:point_3_csv_ref .
 
-ex:point_3_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 3 .
+ex:point_3_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "3" ;
+    acq:dataSource "LAB" .
 
-ex:point_4_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 4 .
+ex:point_4_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "4" ;
+    acq:dataSource "LAB" .
 
 ex:point_5 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium2 ;
     s223:ofSubstance acq:Substance2 ;
     qudt:hasQuantityKind acq:QuantityKind1 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_5_csv_ref .
+    ref:hasExternalReference ex:point_5_csv_ref .
 
-ex:point_5_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 5 .
+ex:point_5_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "5" ;
+    acq:dataSource "LAB" .
 
 ex:point_6 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium3 ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind2 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_6_csv_ref .
+    ref:hasExternalReference ex:point_6_csv_ref .
 
-ex:point_6_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 6 .
+ex:point_6_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "6" ;
+    acq:dataSource "LAB" .
 
 ex:point_7 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium3 ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind2 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_7_csv_ref .
+    ref:hasExternalReference ex:point_7_csv_ref .
 
-ex:point_7_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 7 .
+ex:point_7_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "7" ;
+    acq:dataSource "LAB" .
 
 ex:point_8 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium3 ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind2 ;
     qudt:hasUnit acq:Unit2 ;
-    acq:hasExternalReference ex:point_8_csv_ref .
+    ref:hasExternalReference ex:point_8_csv_ref .
 
-ex:point_8_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 8 .
+ex:point_8_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "8" ;
+    acq:dataSource "LAB" .
 
 ex:point_9 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasEnumerationKind acq:EnumerationKind1 ;
     qudt:hasUnit acq:Unit2 ;
-    acq:hasExternalReference ex:point_9_csv_ref .
+    ref:hasExternalReference ex:point_9_csv_ref .
 
-ex:point_9_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 9 .
+ex:point_9_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "9" ;
+    acq:dataSource "LAB" .
 
 ex:eq_11 a acq:A ;
     acq:x ex:eq_12 ;
@@ -231,7 +227,7 @@ ex:point_4 a acq:QuantifiableObservableProperty ;
     s223:ofSubstance acq:Substance2 ;
     qudt:hasQuantityKind acq:QuantityKind1 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_4_csv_ref .
+    ref:hasExternalReference ex:point_4_csv_ref .
 
 ex:eq_2 a acq:B ;
     acq:hasProperty ex:point_1,

--- a/tests/test_model_csv.ttl
+++ b/tests/test_model_csv.ttl
@@ -1,15 +1,15 @@
 @prefix acq: <urn:acquirium#> .
 @prefix ex: <urn:ex/> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix s223: <http://data.ashrae.org/standard223#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:point_10 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasEnumerationKind acq:EnumerationKind1 ;
     qudt:hasUnit acq:Unit2 ;
-    acq:hasExternalReference ex:point_10_csv_ref .
+    ref:hasExternalReference ex:point_10_csv_ref .
 
 ex:eq_1 a acq:A ;
     acq:hasProperty ex:point_9 ;
@@ -35,116 +35,116 @@ ex:point_1 a acq:QuantifiableObservableProperty ;
     s223:ofSubstance acq:Substance1 ;
     qudt:hasQuantityKind acq:QuantityKind0 ;
     qudt:hasUnit acq:Unit0 ;
-    acq:hasExternalReference ex:point_1_csv_ref .
+    ref:hasExternalReference ex:point_1_csv_ref .
 
-ex:point_10_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 10 .
+ex:point_10_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "10" ;
+    acq:dataSource "LAB" .
 
-ex:point_1_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+ex:point_1_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "1" ;
+    acq:dataSource "LAB" .
 
 ex:point_2 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium1 ;
     s223:ofSubstance acq:Substance1 ;
     qudt:hasQuantityKind acq:QuantityKind0 ;
     qudt:hasUnit acq:Unit0 ;
-    acq:hasExternalReference ex:point_2_csv_ref .
+    ref:hasExternalReference ex:point_2_csv_ref .
 
-ex:point_2_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 2 .
+ex:point_2_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "2" ;
+    acq:dataSource "LAB" .
 
 ex:point_3 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium2 ;
     s223:ofSubstance acq:Substance2 ;
     qudt:hasQuantityKind acq:QuantityKind1 ;
     qudt:hasUnit acq:Unit0 ;
-    acq:hasExternalReference ex:point_3_csv_ref .
+    ref:hasExternalReference ex:point_3_csv_ref .
 
-ex:point_3_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 3 .
+ex:point_3_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "3" ;
+    acq:dataSource "LAB" .
 
-ex:point_4_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 4 .
+ex:point_4_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "4" ;
+    acq:dataSource "LAB" .
 
 ex:point_5 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium2 ;
     s223:ofSubstance acq:Substance2 ;
     qudt:hasQuantityKind acq:QuantityKind1 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_5_csv_ref .
+    ref:hasExternalReference ex:point_5_csv_ref .
 
-ex:point_5_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 5 .
+ex:point_5_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "5" ;
+    acq:dataSource "LAB" .
 
 ex:point_6 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium3 ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind2 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_6_csv_ref .
+    ref:hasExternalReference ex:point_6_csv_ref .
 
-ex:point_6_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 6 .
+ex:point_6_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "6" ;
+    acq:dataSource "LAB" .
 
 ex:point_7 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium3 ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind2 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_7_csv_ref .
+    ref:hasExternalReference ex:point_7_csv_ref .
 
-ex:point_7_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 7 .
+ex:point_7_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "7" ;
+    acq:dataSource "LAB" .
 
 ex:point_8 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium3 ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind2 ;
     qudt:hasUnit acq:Unit2 ;
-    acq:hasExternalReference ex:point_8_csv_ref .
+    ref:hasExternalReference ex:point_8_csv_ref .
 
-ex:point_8_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 8 .
+ex:point_8_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "8" ;
+    acq:dataSource "LAB" .
 
 ex:point_9 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasEnumerationKind acq:EnumerationKind1 ;
     qudt:hasUnit acq:Unit2 ;
-    acq:hasExternalReference ex:point_9_csv_ref .
+    ref:hasExternalReference ex:point_9_csv_ref .
 
-ex:point_9_csv_ref a acq:CSVReference ;
-    acq:DataSource "LAB" ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 9 .
+ex:point_9_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "9" ;
+    acq:dataSource "LAB" .
 
 ex:eq_8 a acq:C ;
     acq:y ex:eq_3 ;
@@ -155,7 +155,7 @@ ex:point_4 a acq:QuantifiableObservableProperty ;
     s223:ofSubstance acq:Substance2 ;
     qudt:hasQuantityKind acq:QuantityKind1 ;
     qudt:hasUnit acq:Unit1 ;
-    acq:hasExternalReference ex:point_4_csv_ref .
+    ref:hasExternalReference ex:point_4_csv_ref .
 
 ex:eq_2 a acq:B ;
     acq:hasProperty ex:point_1,

--- a/tests/test_model_stream.ttl
+++ b/tests/test_model_stream.ttl
@@ -1,6 +1,7 @@
 @prefix acq: <urn:acquirium#> .
 @prefix ex: <urn:ex/> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix s223: <http://data.ashrae.org/standard223#> .
 
 ex:point_11 a acq:QuantifiableObservableProperty ;
@@ -8,60 +9,56 @@ ex:point_11 a acq:QuantifiableObservableProperty ;
     s223:ofSubstance acq:Substance3 ;
     qudt:hasQuantityKind acq:QuantityKind5 ;
     qudt:hasUnit acq:Unit11 ;
-    acq:hasExternalReference ex:point_11_mqtt_ref .
+    ref:hasExternalReference ex:point_11_mqtt_ref .
 
-ex:point_11_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic1" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_11_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic1" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 ex:point_12 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasQuantityKind acq:QuantityKind6 ;
     qudt:hasUnit acq:Unit12 ;
-    acq:hasExternalReference ex:point_12_mqtt_ref .
+    ref:hasExternalReference ex:point_12_mqtt_ref .
 
-ex:point_12_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic2" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_12_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic2" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 ex:point_13 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasQuantityKind acq:QuantityKind6 ;
     qudt:hasUnit acq:Unit13 ;
-    acq:hasExternalReference ex:point_13_mqtt_ref .
+    ref:hasExternalReference ex:point_13_mqtt_ref .
 
-ex:point_13_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic3" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_13_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic3" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 ex:point_14 a acq:QuantifiableObservableProperty ;
     s223:hasMedium acq:Medium4 ;
     s223:ofSubstance acq:Substance4 ;
     qudt:hasQuantityKind acq:QuantityKind7 ;
     qudt:hasUnit acq:Unit14 ;
-    acq:hasExternalReference ex:point_14_mqtt_ref .
+    ref:hasExternalReference ex:point_14_mqtt_ref .
 
-ex:point_14_mqtt_ref a acq:MQTTReference ;
-    acq:Broker "mosquitto" ;
-    acq:DataSource "SCADA" ;
-    acq:Port "1883" ;
-    acq:Topic "topic4" ;
-    acq:time_key "Timestamp" ;
-    acq:value_key "Value" .
+ex:point_14_mqtt_ref a ref:MQTTReference ;
+    ref:MQTTBroker "mosquitto:1883" ;
+    ref:MQTTTopic "topic4" ;
+    acq:dataSource "SCADA" ;
+    acq:timeKey "Timestamp" ;
+    acq:valueKey "Value" .
 
 ex:eq_11 a acq:A ;
     acq:x ex:eq_12 ;

--- a/tests/test_model_units.ttl
+++ b/tests/test_model_units.ttl
@@ -2,6 +2,7 @@
 @prefix ex: <urn:ex/> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix qudtqk: <http://qudt.org/vocab/quantitykind/> .
+@prefix ref: <https://brickschema.org/schema/Brick/ref#> .
 @prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix s223: <http://data.ashrae.org/standard223#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -20,29 +21,29 @@ ex:sensor_1 a acq:A ;
 ex:flow_rate_1 a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:VolumeFlowRate ;
     qudt:hasUnit unit:MilliL-PER-MIN ;
-    acq:hasExternalReference ex:flow_rate_1_csv_ref .
+    ref:hasExternalReference ex:flow_rate_1_csv_ref .
 
-ex:flow_rate_1_csv_ref a acq:CSVReference ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 1 .
+ex:flow_rate_1_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "1" .
 
 # Property WITH unit (volume)
 ex:volume_1 a s223:QuantifiableObservableProperty ;
     qudt:hasQuantityKind qudtqk:Volume ;
     qudt:hasUnit unit:GAL_US ;
-    acq:hasExternalReference ex:volume_1_csv_ref .
+    ref:hasExternalReference ex:volume_1_csv_ref .
 
-ex:volume_1_csv_ref a acq:CSVReference ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 2 .
+ex:volume_1_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "2" .
 
 # Property WITHOUT unit (Case 1: user must provide from_unit and to_unit)
 ex:temp_no_unit a s223:QuantifiableObservableProperty ;
-    acq:hasExternalReference ex:temp_no_unit_csv_ref .
+    ref:hasExternalReference ex:temp_no_unit_csv_ref .
 
-ex:temp_no_unit_csv_ref a acq:CSVReference ;
-    acq:hasFilePath "tests/sample_data.csv" ;
-    acq:hasTimeColumn 0 ;
-    acq:hasValueColumn 3 .
+ex:temp_no_unit_csv_ref a ref:FileReference ;
+    ref:fileLocation "tests/sample_data.csv" ;
+    ref:timeColumnID "0" ;
+    ref:valueColumnID "3" .

--- a/tests/test_query_data.py
+++ b/tests/test_query_data.py
@@ -130,7 +130,7 @@ def test_data_filters(acquirium_client_csv):
     assert len(meta_6) == 2
     assert "point_10" in meta_6["0"].to_list()
 
-    filt_random = query.filter_data_nodes(predicate=ACQUIRIUM_NS.hasExternalReference, value="urn:ex/point_10_csv_ref")
+    filt_random = query.filter_data_nodes(predicate=HAS_EXTERNAL_REFERENCE, value="urn:ex/point_10_csv_ref")
     meta_7 = filt_random.metadata()
     assert len(meta_7) == 1
     assert "point_10" in meta_7["0"].to_list()

--- a/tests/unit/test_app_runner_caching.py
+++ b/tests/unit/test_app_runner_caching.py
@@ -45,9 +45,22 @@ class StubManager:
         for cb in listeners:
             cb()
 
-    def insert_timeseries(self, *, ref_uri: str, rows: Any, point_uri: str | None = None, replace: bool = False) -> int:
+    def insert_timeseries(
+        self,
+        *,
+        source_id: str,
+        ref_name: str,
+        rows: Any,
+        point_uri: str | None = None,
+        replace: bool = False,
+    ) -> int:
         self.timeseries_inserts.append(
-            {"ref_uri": ref_uri, "rows": list(rows), "point_uri": point_uri}
+            {
+                "source_id": source_id,
+                "ref_name": ref_name,
+                "rows": list(rows),
+                "point_uri": point_uri,
+            }
         )
         return len(rows)
 

--- a/tests/unit/test_app_utils.py
+++ b/tests/unit/test_app_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from acquirium.internals.app_utils import _safe_fragment, app_uri_for, make_stream_ref_uri
+from acquirium.internals.app_utils import _safe_fragment, app_uri_for
 
 
 class TestSafeFragment:
@@ -30,23 +30,3 @@ class TestAppUriFor:
         uri = app_uri_for("my app")
         assert "urn:acquirium#app/" in uri
         assert " " not in uri
-
-
-class TestMakeStreamRefUri:
-    def test_deterministic(self):
-        uri1 = make_stream_ref_uri("urn:test:point1")
-        uri2 = make_stream_ref_uri("urn:test:point1")
-        assert uri1 == uri2
-
-    def test_different_inputs_differ(self):
-        uri1 = make_stream_ref_uri("urn:test:point1")
-        uri2 = make_stream_ref_uri("urn:test:point2")
-        assert uri1 != uri2
-
-    def test_format(self):
-        uri = make_stream_ref_uri("urn:test:point1")
-        assert uri.startswith("urn:acquirium#stream/")
-        # 12 hex chars after prefix
-        suffix = uri.split("stream/")[1]
-        assert len(suffix) == 12
-        int(suffix, 16)  # should not raise

--- a/tests/unit/test_apps_output.py
+++ b/tests/unit/test_apps_output.py
@@ -4,7 +4,6 @@ import pytest
 from datetime import datetime, timezone
 
 from acquirium.Apps.base import Output
-from acquirium.internals.app_utils import make_stream_ref_uri
 
 
 # ── Output.timeseries ──────────────────────────────────────
@@ -33,22 +32,6 @@ class TestOutputTimeseries:
     def test_no_rows_no_series_raises(self):
         with pytest.raises(ValueError, match="rows or series"):
             Output.timeseries(point_uri="urn:test:p1")
-
-    def test_auto_ref_uri(self):
-        out = Output.timeseries(
-            point_uri="urn:test:p1",
-            rows=[(datetime(2025, 1, 1, tzinfo=timezone.utc), 1.0)],
-        )
-        expected_ref = make_stream_ref_uri("urn:test:p1")
-        assert out.payload["ref_uri"] == expected_ref
-
-    def test_explicit_ref_uri(self):
-        out = Output.timeseries(
-            point_uri="urn:test:p1",
-            rows=[(datetime(2025, 1, 1, tzinfo=timezone.utc), 1.0)],
-            ref_uri="urn:custom:ref",
-        )
-        assert out.payload["ref_uri"] == "urn:custom:ref"
 
 
 # ── Output.event ───────────────────────────────────────────


### PR DESCRIPTION
Wanted to prototype what a live data upload could look like

- added a system metrics script to show how we could add graph metadata + timeseries. Resolves QUDT metadata to use the right keys
	- adds data under 'ref_uri'
- added `register_stream` to add metadata to the graph:
	- maps the ref_uri to the point_uri (in the graph)
 - added batch timeseries ingestion and unified /insert_timeseries endpoint to support single and multi-stream uploading
- fixed up some docker stuff (minimal compose file, cache-friendly Dockerfile for server)
- added a data lifecycle description to describe how the new ids work. We are differentiating between source-specific ids (Source name + data reference name) and the "real" URIs that exist in the model (the Point / Property URIs). The linking can be done by client using "register_stream"