### PR TITLE
Drivers maintain local state

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -213,6 +213,112 @@ def setup(self):
     self.aq.register_datasource(self.source_id)
 ```
 
+## Persistent State
+
+Drivers can persist state across restarts using `self.state`, a key-value store
+backed by JSON files. State is stored in `.acquirium/drivers/<driver-id>.json`
+relative to the config directory.
+
+### State API
+
+```python
+# Get a value (with optional default)
+offset = self.state.get("last_offset", default=0)
+
+# Set a value (auto-saves to disk)
+self.state.set("last_offset", 150)
+
+# Delete a key
+self.state.delete("temp_data")
+
+# List all keys
+keys = self.state.keys()
+
+# Update multiple keys at once
+self.state.update({"offset": 200, "cursor": "abc123"})
+
+# Check if a key exists
+if "last_offset" in self.state:
+    ...
+```
+
+### Driver Identifier
+
+The state file is named based on a driver identifier, determined as follows:
+
+1. **Explicit `driver_id`** (recommended for human-readable names):
+   ```toml
+   [[drivers]]
+   spec = "acquirium.BuiltinDrivers.csv_ingest:CSVIngestDriver"
+   driver_id = "my-csv-monitor"
+   ```
+   → State file: `.acquirium/drivers/my-csv-monitor.json`
+
+2. **Derived from spec** (if `driver_id` not provided):
+   - A hash of the spec combined with the class name
+   - Example: `CSVIngestDriver_a1b2c3d4e5f6g7h8.json`
+
+### Example: CSV Driver with `driver_id`
+
+```toml
+[[drivers]]
+spec = "acquirium.BuiltinDrivers.csv_ingest:CSVIngestDriver"
+interval = 5.0
+watch_dir = "./data/incoming"
+driver_id = "sensor-data-ingest"  # Human-readable state file name
+```
+
+Row offsets are automatically persisted, so restarting the driver resumes
+from where it left off.
+
+### Example: Custom Driver with API Cursor
+
+```python
+from acquirium import PollingIngestDriver
+import polars as pl
+
+class APIPollingDriver(PollingIngestDriver):
+    def setup(self):
+        self.source_id = "api-source"
+        self.aq.register_datasource(self.source_id)
+        self.aq.register_stream(self.source_id, "metric/value", "numeric")
+
+    def collect(self):
+        # Load cursor from persistent state
+        cursor = self.state.get("api_cursor", default=None)
+
+        # Fetch data from API using cursor
+        data = fetch_api_page(cursor=cursor)
+
+        # Save new cursor for next tick
+        if data.next_cursor:
+            self.state.set("api_cursor", data.next_cursor)
+
+        return pl.DataFrame({
+            "ts": data.timestamps,
+            "ref_name": data.names,
+            "value": data.values,
+        })
+```
+
+### Example: Custom Checkpointing
+
+```python
+class ProcessingDriver(PollingIngestDriver):
+    def collect(self):
+        # Load checkpoint
+        checkpoint = self.state.get("processing_checkpoint", default={"id": 0})
+
+        # Process batch starting from checkpoint
+        batch = fetch_batch(after_id=checkpoint["id"])
+
+        # Update checkpoint after successful processing
+        if batch:
+            self.state.set("processing_checkpoint", {"id": batch.last_id})
+
+        return batch.to_dataframe()
+```
+
 ## Reference URIs
 
 Drivers should use the canonical reference helper instead of inventing their

--- a/src/acquirium/BuiltinDrivers/_tabular_base.py
+++ b/src/acquirium/BuiltinDrivers/_tabular_base.py
@@ -153,6 +153,8 @@ class _TabularIngestBase(IngestDriver):
 
             if result.get("ok"):
                 self._rows_seen[key] = offset + rows_read
+                # Persist updated row offsets
+                self.state.set("rows_seen", self._rows_seen)
                 logger.info(
                     "tabular_ingest: %s — inserted %d row(s) across %d stream(s)",
                     rel, result.get("rows_inserted", 0), len(stream_names),

--- a/src/acquirium/BuiltinDrivers/_tabular_base.py
+++ b/src/acquirium/BuiltinDrivers/_tabular_base.py
@@ -69,7 +69,8 @@ class _TabularIngestBase(IngestDriver):
         if not watch_dir.is_absolute():
             watch_dir = (self.config_dir() / watch_dir).resolve()
         self._watch_dir = watch_dir
-        self._rows_seen: dict[str, int] = {}
+        # Load row offsets from persistent state (empty dict if not found)
+        self._rows_seen: dict[str, int] = self.state.get("rows_seen", {})
         self._registered: dict[str, set[str]] = {}  # source_id → registered ref_names
 
         self._watch_dir.mkdir(parents=True, exist_ok=True)

--- a/src/acquirium/Driver.py
+++ b/src/acquirium/Driver.py
@@ -115,20 +115,6 @@ class Driver(ABC):
         state_file = self.config_dir() / ".acquirium" / "drivers" / f"{identifier}.json"
         return DriverState(state_file)
 
-
-def _sanitize_filename(name: str) -> str:
-    """Sanitize a string for use as a filename.
-
-    Replaces unsafe characters with underscores.
-    """
-    unsafe = "<>:" "|?*\\"
-    result = name
-    for char in unsafe:
-        result = result.replace(char, "_")
-    # Also replace spaces and other problematic chars
-    result = result.strip().replace(" ", "_")
-    return result
-
     @abstractmethod
     def setup(self) -> None:
         """One-time initialisation: register_datasource, insert RDF, etc.
@@ -159,6 +145,20 @@ def _sanitize_filename(name: str) -> str:
 
         Default is a no-op.  Override to close file ref URIs, flush buffers, etc.
         """
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a string for use as a filename.
+
+    Replaces unsafe characters with underscores.
+    """
+    unsafe = "<>:" "|?*\\"
+    result = name
+    for char in unsafe:
+        result = result.replace(char, "_")
+    # Also replace spaces and other problematic chars
+    result = result.strip().replace(" ", "_")
+    return result
 
 
 class IngestDriver(Driver):

--- a/src/acquirium/Driver.py
+++ b/src/acquirium/Driver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
@@ -7,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from rdflib import URIRef
 
+from acquirium.DriverState import DriverState
 from acquirium.internals.models import compute_ref_uri
 
 if TYPE_CHECKING:
@@ -66,6 +68,8 @@ class Driver(ABC):
         self.aq = aq
         # Full parsed TOML dict so drivers can read their own config sections.
         self.config = config
+        # Persistent state storage
+        self.state = self._init_state(config)
 
     def reference_uri(self, ref_name: str) -> URIRef:
         """Return the canonical reference URI for ``self.source_id``/``ref_name``."""
@@ -74,6 +78,56 @@ class Driver(ABC):
     def config_dir(self) -> Path:
         """Return the directory containing the loaded config file, if known."""
         return Path(self.config.get("__config_dir", Path.cwd()))
+
+    def _init_state(self, config: dict) -> DriverState:
+        """Initialize persistent state for this driver.
+
+        Derives a unique identifier from the driver config:
+        - Uses `driver_id` if provided in config
+        - Otherwise derives deterministically from the driver spec
+
+        Args:
+            config: The full configuration dictionary.
+
+        Returns:
+            A DriverState instance backed by a JSON file.
+        """
+        # Get driver spec from config (used for deriving identifier)
+        driver_section = config.get("driver", {})
+        driver_id = driver_section.get("driver_id")
+
+        if driver_id:
+            # Use explicit driver_id if provided (sanitize for filesystem)
+            identifier = _sanitize_filename(str(driver_id))
+        else:
+            # Derive from spec hash for stability
+            spec = driver_section.get("spec", "")
+            if spec:
+                # Hash the spec to create a stable identifier
+                spec_hash = hashlib.sha256(spec.encode()).hexdigest()[:16]
+                # Also include class name for readability
+                class_name = self.__class__.__name__
+                identifier = f"{_sanitize_filename(class_name)}_{spec_hash}"
+            else:
+                # Fallback to class name only
+                identifier = _sanitize_filename(self.__class__.__name__)
+
+        state_file = self.config_dir() / ".acquirium" / "drivers" / f"{identifier}.json"
+        return DriverState(state_file)
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a string for use as a filename.
+
+    Replaces unsafe characters with underscores.
+    """
+    unsafe = "<>:" "|?*\\"
+    result = name
+    for char in unsafe:
+        result = result.replace(char, "_")
+    # Also replace spaces and other problematic chars
+    result = result.strip().replace(" ", "_")
+    return result
 
     @abstractmethod
     def setup(self) -> None:

--- a/src/acquirium/DriverState.py
+++ b/src/acquirium/DriverState.py
@@ -1,0 +1,166 @@
+"""Persistent driver state management.
+
+Provides a simple key-value store backed by JSON files, allowing drivers
+to persist state across restarts (e.g., row offsets, API cursors, checkpoints).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("acquirium.driver_state")
+
+
+class DriverState:
+    """Persistent key-value store for driver state.
+
+    State is stored in a JSON file and automatically saved on mutations.
+    Thread-safe for concurrent access.
+
+    Example::
+
+        # Store a value
+        self.state.set("last_offset", 150)
+
+        # Retrieve a value with default
+        offset = self.state.get("last_offset", default=0)
+
+        # Delete a key
+        self.state.delete("temp_data")
+
+        # List all keys
+        keys = self.state.keys()
+    """
+
+    def __init__(self, state_file: Path) -> None:
+        """Initialize driver state.
+
+        Args:
+            state_file: Path to the JSON file for storing state.
+                       Parent directories will be created if needed.
+        """
+        self._state_file = state_file
+        self._lock = threading.Lock()
+        self._cache: dict[str, Any] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load state from JSON file."""
+        if not self._state_file.exists():
+            self._cache = {}
+            return
+
+        try:
+            content = self._state_file.read_text(encoding="utf-8")
+            self._cache = json.loads(content)
+            if not isinstance(self._cache, dict):
+                logger.warning(
+                    "State file %s is not a JSON object, resetting state",
+                    self._state_file,
+                )
+                self._cache = {}
+        except json.JSONDecodeError:
+            logger.error(
+                "State file %s contains invalid JSON, resetting state",
+                self._state_file,
+            )
+            self._cache = {}
+        except Exception:
+            logger.exception("Failed to load state from %s", self._state_file)
+            self._cache = {}
+
+    def _save(self) -> None:
+        """Save state to JSON file."""
+        try:
+            self._state_file.parent.mkdir(parents=True, exist_ok=True)
+            content = json.dumps(self._cache, indent=2, default=str)
+            self._state_file.write_text(content, encoding="utf-8")
+        except Exception:
+            logger.exception("Failed to save state to %s", self._state_file)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get a value from state.
+
+        Args:
+            key: The state key to retrieve.
+            default: Value to return if key doesn't exist.
+
+        Returns:
+            The stored value, or default if key not found.
+        """
+        with self._lock:
+            return self._cache.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a value in state.
+
+        Automatically saves to disk after mutation.
+
+        Args:
+            key: The state key to set.
+            value: The value to store (must be JSON-serializable).
+        """
+        with self._lock:
+            self._cache[key] = value
+            self._save()
+
+    def delete(self, key: str) -> bool:
+        """Delete a key from state.
+
+        Automatically saves to disk after mutation.
+
+        Args:
+            key: The state key to delete.
+
+        Returns:
+            True if the key existed and was deleted, False otherwise.
+        """
+        with self._lock:
+            if key in self._cache:
+                del self._cache[key]
+                self._save()
+                return True
+            return False
+
+    def keys(self) -> list[str]:
+        """Get all state keys.
+
+        Returns:
+            List of all keys in the state store.
+        """
+        with self._lock:
+            return list(self._cache.keys())
+
+    def clear(self) -> None:
+        """Clear all state.
+
+        Automatically saves to disk after mutation.
+        """
+        with self._lock:
+            self._cache = {}
+            self._save()
+
+    def update(self, data: dict[str, Any]) -> None:
+        """Update state with multiple key-value pairs.
+
+        Automatically saves to disk after mutation.
+
+        Args:
+            data: Dictionary of key-value pairs to update.
+        """
+        with self._lock:
+            self._cache.update(data)
+            self._save()
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a key exists in state."""
+        with self._lock:
+            return key in self._cache
+
+    def __repr__(self) -> str:
+        with self._lock:
+            return f"DriverState({self._state_file.name}: {len(self._cache)} keys)"

--- a/tests/unit/test_driver_state.py
+++ b/tests/unit/test_driver_state.py
@@ -1,0 +1,244 @@
+"""Tests for DriverState persistent storage."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from acquirium.DriverState import DriverState
+
+
+class TestDriverState:
+    """Tests for DriverState class."""
+
+    def test_get_set_basic(self, tmp_path: Path) -> None:
+        """Test basic get/set operations."""
+        state_file = tmp_path / "state.json"
+        state = DriverState(state_file)
+
+        state.set("key1", "value1")
+        assert state.get("key1") == "value1"
+
+    def test_get_with_default(self, tmp_path: Path) -> None:
+        """Test get with default value."""
+        state = DriverState(tmp_path / "state.json")
+
+        # Non-existent key returns default
+        assert state.get("nonexistent", default="default_val") == "default_val"
+
+        # None is valid default
+        assert state.get("also_missing") is None
+
+    def test_set_persists_to_disk(self, tmp_path: Path) -> None:
+        """Test that set() writes to disk immediately."""
+        state_file = tmp_path / "state.json"
+        state = DriverState(state_file)
+
+        state.set("key1", "value1")
+
+        # Verify file was created and contains data
+        assert state_file.exists()
+        content = json.loads(state_file.read_text())
+        assert content["key1"] == "value1"
+
+    def test_persistence_across_instances(self, tmp_path: Path) -> None:
+        """Test that state survives driver restart (new instance)."""
+        state_file = tmp_path / "state.json"
+
+        # First instance: set value
+        state1 = DriverState(state_file)
+        state1.set("counter", 42)
+        state1.set("name", "test_driver")
+
+        # Second instance: verify value loaded
+        state2 = DriverState(state_file)
+        assert state2.get("counter") == 42
+        assert state2.get("name") == "test_driver"
+
+    def test_delete(self, tmp_path: Path) -> None:
+        """Test delete operation."""
+        state = DriverState(tmp_path / "state.json")
+
+        state.set("to_delete", "value")
+        assert "to_delete" in state
+
+        result = state.delete("to_delete")
+        assert result is True
+        assert "to_delete" not in state
+        assert state.get("to_delete") is None
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        """Test delete on non-existent key returns False."""
+        state = DriverState(tmp_path / "state.json")
+        assert state.delete("never_existed") is False
+
+    def test_keys(self, tmp_path: Path) -> None:
+        """Test keys() returns all stored keys."""
+        state = DriverState(tmp_path / "state.json")
+
+        state.set("a", 1)
+        state.set("b", 2)
+        state.set("c", 3)
+
+        keys = set(state.keys())
+        assert keys == {"a", "b", "c"}
+
+    def test_clear(self, tmp_path: Path) -> None:
+        """Test clear() removes all keys."""
+        state = DriverState(tmp_path / "state.json")
+
+        state.set("key1", "value1")
+        state.set("key2", "value2")
+
+        state.clear()
+
+        assert state.keys() == []
+        assert state.get("key1") is None
+
+    def test_update(self, tmp_path: Path) -> None:
+        """Test update() with multiple key-value pairs."""
+        state = DriverState(tmp_path / "state.json")
+
+        state.update({"a": 1, "b": 2, "c": 3})
+
+        assert state.get("a") == 1
+        assert state.get("b") == 2
+        assert state.get("c") == 3
+
+    def test_contains(self, tmp_path: Path) -> None:
+        """Test __contains__ operator."""
+        state = DriverState(tmp_path / "state.json")
+
+        state.set("exists", "value")
+
+        assert "exists" in state
+        assert "not_exists" not in state
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test __repr__ shows state file name and key count."""
+        state = DriverState(tmp_path / "my_state.json")
+        state.set("k1", "v1")
+        state.set("k2", "v2")
+
+        repr_str = repr(state)
+        assert "my_state.json" in repr_str
+        assert "2 keys" in repr_str
+
+    def test_handles_corrupt_json(self, tmp_path: Path) -> None:
+        """Test that corrupt JSON file resets state gracefully."""
+        state_file = tmp_path / "state.json"
+        state_file.write_text("not valid json {{{")
+
+        # Should not raise, should reset to empty state
+        state = DriverState(state_file)
+        assert state.keys() == []
+
+    def test_handles_non_object_json(self, tmp_path: Path) -> None:
+        """Test that non-object JSON (array, string) resets state."""
+        state_file = tmp_path / "state.json"
+        state_file.write_text('["not", "an", "object"]')
+
+        state = DriverState(state_file)
+        assert state.keys() == []
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        """Test that parent directories are created if needed."""
+        state_file = tmp_path / "subdir" / "nested" / "state.json"
+
+        state = DriverState(state_file)
+        state.set("key", "value")
+
+        assert state_file.exists()
+
+    def test_complex_types(self, tmp_path: Path) -> None:
+        """Test storing complex JSON-serializable types."""
+        state = DriverState(tmp_path / "state.json")
+
+        # Dict
+        state.set("config", {"timeout": 30, "retries": 3})
+
+        # List
+        state.set("items", [1, 2, 3])
+
+        # Nested
+        state.set("nested", {"outer": {"inner": "value"}})
+
+        assert state.get("config") == {"timeout": 30, "retries": 3}
+        assert state.get("items") == [1, 2, 3]
+        assert state.get("nested") == {"outer": {"inner": "value"}}
+
+    def test_rows_seen_pattern(self, tmp_path: Path) -> None:
+        """Test the common pattern of storing rows_seen dict."""
+        state = DriverState(tmp_path / "state.json")
+
+        # Simulate CSV driver pattern
+        rows_seen = {
+            "/path/to/file1.csv": 150,
+            "/path/to/file2.csv": 42,
+        }
+        state.set("rows_seen", rows_seen)
+
+        # Reload and verify
+        state2 = DriverState(tmp_path / "state.json")
+        loaded = state2.get("rows_seen", default={})
+
+        assert loaded == rows_seen
+        assert loaded["/path/to/file1.csv"] == 150
+
+    def test_api_cursor_pattern(self, tmp_path: Path) -> None:
+        """Test the common pattern of storing API cursor."""
+        state = DriverState(tmp_path / "state.json")
+
+        # Simulate API polling driver pattern
+        cursor = state.get("api_cursor", default=None)
+        assert cursor is None
+
+        state.set("api_cursor", "abc123xyz")
+
+        state2 = DriverState(tmp_path / "state.json")
+        assert state2.get("api_cursor") == "abc123xyz"
+
+    def test_thread_safety_basic(self, tmp_path: Path) -> None:
+        """Test basic thread safety with concurrent writes."""
+        import threading
+
+        state = DriverState(tmp_path / "state.json")
+        errors = []
+
+        def writer(thread_id: int) -> None:
+            try:
+                for i in range(100):
+                    state.set(f"thread_{thread_id}_key_{i}", i)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+    def test_empty_file_initialization(self, tmp_path: Path) -> None:
+        """Test handling of empty state file."""
+        state_file = tmp_path / "state.json"
+        state_file.write_text("")
+
+        state = DriverState(state_file)
+        assert state.keys() == []
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        """Test initialization when state file doesn't exist."""
+        state_file = tmp_path / "nonexistent.json"
+
+        # Should not raise
+        state = DriverState(state_file)
+        assert state.keys() == []
+
+        # After set, file should exist
+        state.set("key", "value")
+        assert state_file.exists()

--- a/tests/unit/test_driver_state_integration.py
+++ b/tests/unit/test_driver_state_integration.py
@@ -1,0 +1,323 @@
+"""Tests for Driver state integration and identifier derivation."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from acquirium.Driver import Driver, _sanitize_filename
+
+
+class MockAcquirium:
+    """Mock Acquirium client for testing."""
+
+    pass
+
+
+class MockDriver(Driver):
+    """Mock driver for testing state initialization."""
+
+    def setup(self) -> None:
+        pass
+
+    def tick(self) -> None:
+        pass
+
+
+class TestSanitizeFilename:
+    """Tests for _sanitize_filename helper."""
+
+    def test_simple_name(self) -> None:
+        """Test simple alphanumeric name."""
+        assert _sanitize_filename("my-driver") == "my-driver"
+
+    def test_spaces_replaced(self) -> None:
+        """Test spaces are replaced with underscores."""
+        assert _sanitize_filename("my driver") == "my_driver"
+
+    def test_colon_replaced(self) -> None:
+        """Test colons are replaced."""
+        assert _sanitize_filename("module:Driver") == "module_Driver"
+
+    def test_pipe_replaced(self) -> None:
+        """Test pipe characters are replaced."""
+        assert _sanitize_filename("driver|name") == "driver_name"
+
+    def test_question_mark_replaced(self) -> None:
+        """Test question marks are replaced."""
+        assert _sanitize_filename("driver?name") == "driver_name"
+
+    def test_asterisk_replaced(self) -> None:
+        """Test asterisks are replaced."""
+        assert _sanitize_filename("driver*name") == "driver_name"
+
+    def test_backslash_replaced(self) -> None:
+        """Test backslashes are replaced."""
+        assert _sanitize_filename("driver\\name") == "driver_name"
+
+    def test_less_than_replaced(self) -> None:
+        """Test less-than signs are replaced."""
+        assert _sanitize_filename("driver<name") == "driver_name"
+
+    def test_greater_than_replaced(self) -> None:
+        """Test greater-than signs are replaced."""
+        assert _sanitize_filename("driver>name") == "driver_name"
+
+    def test_pipe_replaced(self) -> None:
+        """Test pipe characters are replaced."""
+        assert _sanitize_filename("driver|name") == "driver_name"
+
+    def test_mixed_unsafe_chars(self) -> None:
+        """Test multiple unsafe characters."""
+        assert _sanitize_filename("module:Driver-Class") == "module_Driver-Class"
+
+
+class TestDriverStateIntegration:
+    """Tests for Driver state initialization."""
+
+    def test_state_initialized_with_driver_id(self, tmp_path: Path) -> None:
+        """Test state file uses explicit driver_id when provided."""
+        config = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "test.module:MockDriver",
+                "driver_id": "my-custom-driver",
+            },
+        }
+
+        driver = MockDriver(MockAcquirium(), config)
+
+        # Verify state file path
+        expected_path = tmp_path / ".acquirium" / "drivers" / "my-custom-driver.json"
+        assert driver.state._state_file == expected_path
+
+    def test_state_initialized_without_driver_id(self, tmp_path: Path) -> None:
+        """Test state file is derived from spec when driver_id not provided."""
+        config = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "test.module:MockDriver",
+            },
+        }
+
+        driver = MockDriver(MockAcquirium(), config)
+
+        # Verify state file exists in correct location
+        state_file = driver.state._state_file
+        assert state_file.parent == tmp_path / ".acquirium" / "drivers"
+        assert state_file.suffix == ".json"
+
+        # Verify filename contains class name
+        assert "MockDriver" in state_file.stem
+
+    def test_state_file_created_on_first_set(self, tmp_path: Path) -> None:
+        """Test state file is created when first value is set."""
+        config = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "test.module:MockDriver",
+                "driver_id": "test-driver",
+            },
+        }
+
+        driver = MockDriver(MockAcquirium(), config)
+
+        # File shouldn't exist yet
+        assert not driver.state._state_file.exists()
+
+        # Set a value
+        driver.state.set("key", "value")
+
+        # File should now exist
+        assert driver.state._state_file.exists()
+
+    def test_state_persists_across_driver_instances(self, tmp_path: Path) -> None:
+        """Test state survives across driver restarts (new instances)."""
+        config = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "test.module:MockDriver",
+                "driver_id": "persistent-driver",
+            },
+        }
+
+        # First driver instance
+        driver1 = MockDriver(MockAcquirium(), config)
+        driver1.state.set("counter", 42)
+
+        # Second driver instance (simulating restart)
+        driver2 = MockDriver(MockAcquirium(), config)
+        assert driver2.state.get("counter") == 42
+
+    def test_state_isolated_between_drivers(self, tmp_path: Path) -> None:
+        """Test different drivers have isolated state files."""
+        config1 = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "test.module:Driver1",
+                "driver_id": "driver-one",
+            },
+        }
+
+        config2 = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "test.module:Driver2",
+                "driver_id": "driver-two",
+            },
+        }
+
+        driver1 = MockDriver(MockAcquirium(), config1)
+        driver2 = MockDriver(MockAcquirium(), config2)
+
+        driver1.state.set("key", "value1")
+        driver2.state.set("key", "value2")
+
+        # Each driver should only see its own value
+        assert driver1.state.get("key") == "value1"
+        assert driver2.state.get("key") == "value2"
+
+    def test_state_with_relative_config_dir(self, tmp_path: Path) -> None:
+        """Test state file path works with relative config directory."""
+        # Create a subdirectory to use as config dir
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        config = {
+            "__config_dir": str(config_dir),
+            "driver": {
+                "spec": "test.module:MockDriver",
+                "driver_id": "test-driver",
+            },
+        }
+
+        driver = MockDriver(MockAcquirium(), config)
+
+        expected_path = config_dir / ".acquirium" / "drivers" / "test-driver.json"
+        assert driver.state._state_file == expected_path
+
+    def test_state_loads_existing_data(self, tmp_path: Path) -> None:
+        """Test state loads existing data from file on initialization."""
+        # Create state file with pre-existing data
+        state_dir = tmp_path / ".acquirium" / "drivers"
+        state_dir.mkdir(parents=True)
+        state_file = state_dir / "preload-driver.json"
+        state_file.write_text('{"counter": 100, "cursor": "abc123"}')
+
+        config = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "test.module:MockDriver",
+                "driver_id": "preload-driver",
+            },
+        }
+
+        driver = MockDriver(MockAcquirium(), config)
+
+        # Verify data was loaded
+        assert driver.state.get("counter") == 100
+        assert driver.state.get("cursor") == "abc123"
+
+    def test_state_default_spec_hash(self, tmp_path: Path) -> None:
+        """Test that spec hash is used when no driver_id is provided."""
+        config = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "acquirium.BuiltinDrivers.csv_ingest:CSVIngestDriver",
+            },
+        }
+
+        # We need a real driver class for this test
+        from acquirium.BuiltinDrivers.csv_ingest import CSVIngestDriver
+
+        # Create a minimal mock for the Acquirium client
+        class MockAQ:
+            pass
+
+        driver = CSVIngestDriver(MockAQ(), config)
+
+        # Verify state file was created
+        state_file = driver.state._state_file
+        assert state_file.parent == tmp_path / ".acquirium" / "drivers"
+        assert state_file.suffix == ".json"
+        assert "CSVIngestDriver" in state_file.stem
+
+
+class TestDriverIdentifierDerivation:
+    """Tests for driver identifier derivation logic."""
+
+    def test_spec_hash_is_deterministic(self, tmp_path: Path) -> None:
+        """Test that the same spec always produces the same hash."""
+        spec = "acquirium.BuiltinDrivers.csv_ingest:CSVIngestDriver"
+        expected_hash = hashlib.sha256(spec.encode()).hexdigest()[:16]
+
+        config1 = {
+            "__config_dir": str(tmp_path),
+            "driver": {"spec": spec},
+        }
+
+        config2 = {
+            "__config_dir": str(tmp_path),
+            "driver": {"spec": spec},
+        }
+
+        from acquirium.BuiltinDrivers.csv_ingest import CSVIngestDriver
+
+        class MockAQ:
+            pass
+
+        driver1 = CSVIngestDriver(MockAQ(), config1)
+        driver2 = CSVIngestDriver(MockAQ(), config2)
+
+        # Both should have the same hash in their filename
+        assert expected_hash in driver1.state._state_file.stem
+        assert expected_hash in driver2.state._state_file.stem
+
+    def test_different_specs_different_hashes(self, tmp_path: Path) -> None:
+        """Test that different specs produce different hashes."""
+        spec1 = "acquirium.BuiltinDrivers.csv_ingest:CSVIngestDriver"
+        spec2 = "acquirium.BuiltinDrivers.xlsx_ingest:XLSXIngestDriver"
+
+        config1 = {
+            "__config_dir": str(tmp_path),
+            "driver": {"spec": spec1},
+        }
+
+        config2 = {
+            "__config_dir": str(tmp_path),
+            "driver": {"spec": spec2},
+        }
+
+        from acquirium.BuiltinDrivers.csv_ingest import CSVIngestDriver
+        from acquirium.BuiltinDrivers.xlsx_ingest import XLSXIngestDriver
+
+        class MockAQ:
+            pass
+
+        driver1 = CSVIngestDriver(MockAQ(), config1)
+        driver2 = XLSXIngestDriver(MockAQ(), config2)
+
+        # Filenames should be different
+        assert driver1.state._state_file.name != driver2.state._state_file.name
+
+    def test_driver_id_takes_precedence_over_spec(self, tmp_path: Path) -> None:
+        """Test that driver_id is used instead of spec hash when provided."""
+        config = {
+            "__config_dir": str(tmp_path),
+            "driver": {
+                "spec": "acquirium.BuiltinDrivers.csv_ingest:CSVIngestDriver",
+                "driver_id": "explicit-name",
+            },
+        }
+
+        from acquirium.BuiltinDrivers.csv_ingest import CSVIngestDriver
+
+        class MockAQ:
+            pass
+
+        driver = CSVIngestDriver(MockAQ(), config)
+
+        # Should use explicit name, not hash
+        assert driver.state._state_file.stem == "explicit-name"


### PR DESCRIPTION
This adds persistent per-driver state so drivers can safely resume work across restarts.

 Each driver now gets `self.state`, a JSON-backed key-value store under `.acquirium/drivers/` relative to the config directory. Drivers can use it for row offsets, API cursors,
 checkpoints, and other lightweight state that should survive process restarts.

 ## Changes

 - Add `DriverState`, a thread-safe JSON-backed key-value store.
 - Initialize `self.state` on the base `Driver`.
 - Support explicit `driver_id` for stable, human-readable state file names.
 - Derive a deterministic fallback state identifier from the driver spec when `driver_id` is not provided.
 - Persist tabular ingest `rows_seen` offsets after successful inserts.
 - Load tabular ingest row offsets from persistent state during setup.
 - Document the persistent state API and driver identifier behavior in `docs/drivers.md`.
