### PR TITLE
Improve graph store startup, union-query performance, and ontoenv cache correctness

### DIFF
--- a/src/acquirium/BuiltinDrivers/_tabular_base.py
+++ b/src/acquirium/BuiltinDrivers/_tabular_base.py
@@ -146,6 +146,13 @@ class _TabularIngestBase(IngestDriver):
                 self.aq.register_datasource(source_id)
             self._ensure_streams(stream_names, source_id, value_kinds)
 
+            logger.info(
+                "tabular_ingest: %s — forwarding %d row(s) across %d stream(s) for source_id=%s",
+                rel,
+                len(df),
+                len(stream_names),
+                source_id,
+            )
             result = self.insert_observations(
                 df.with_columns(pl.lit(source_id).alias("source_id"))
             )

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -61,7 +61,9 @@ def _start_inprocess_drivers(
         log.warning("Could not load config from ACQUIRIUM_CONFIG=%s; skipping in-process drivers", config_path)
         return []
 
-    threads: list[threading.Thread] = []
+    # Stage every driver first so setup-time graph writes cannot race with
+    # another driver's tick loop.
+    drivers_to_start: list[tuple[str, float, object, object]] = []
     for entry in cfg.get("drivers", []):
         spec = entry.get("spec")
         if not spec:
@@ -79,12 +81,18 @@ def _start_inprocess_drivers(
                 insert_batch_rows=int(merged_cfg.get("driver", {}).get("insert_batch_rows", 50_000)),
             )
             driver = driver_cls(direct_aq, merged_cfg)
+            log.info("Setting up in-process driver: %s", spec)
             driver.setup()
             log.info("In-process driver ready: %s", driver_cls.__name__)
+            drivers_to_start.append((spec, interval, driver, direct_aq))
         except Exception:
             log.exception("In-process driver %s setup failed; thread exiting", spec)
             continue
 
+    # Only start background loops after all setups have either succeeded or
+    # failed, so later drivers are not competing with earlier tick threads.
+    threads: list[threading.Thread] = []
+    for spec, interval, driver, direct_aq in drivers_to_start:
         t = threading.Thread(
             target=_run_driver_loop,
             args=(driver, direct_aq, interval, stop_event),

--- a/src/acquirium/Server/app.py
+++ b/src/acquirium/Server/app.py
@@ -38,49 +38,18 @@ from acquirium.Server.insert_stats import insert_stats, start_insert_summary_thr
 
 log = logging.getLogger("acquirium.api")
 
-# ---------------------------------------------------------------------------
-# In-process driver helpers
-# ---------------------------------------------------------------------------
-
-def _run_inprocess_driver(
-    entry: dict,
-    manager: Manager,
-    cfg: dict,
-    stop_event: threading.Event,
-) -> None:
-    """Thread target: run a single [[drivers]] entry using DirectAcquirium."""
-    from acquirium.Server.direct_client import DirectAcquirium
-    from acquirium.cli import _import_driver_class, _run_driver_loop
-
-    spec = entry["spec"]
-    driver_overrides = {k: v for k, v in entry.items() if k != "spec"}
-    merged_cfg = {**cfg, "driver": {**cfg.get("driver", {}), **driver_overrides}}
-    interval = float(driver_overrides.get("interval", cfg.get("driver", {}).get("interval", 10.0)))
-    config_dir = Path(cfg.get("__config_dir", Path.cwd()))
-
-    try:
-        driver_cls = _import_driver_class(spec, base_dir=config_dir)
-        direct_aq = DirectAcquirium(
-            manager,
-            origin=spec,
-            insert_batch_rows=int(merged_cfg.get("driver", {}).get("insert_batch_rows", 50_000)),
-        )
-        driver = driver_cls(direct_aq, merged_cfg)
-        driver.setup()
-        log.info("In-process driver ready: %s", driver_cls.__name__)
-    except Exception:
-        log.exception("In-process driver %s setup failed; thread exiting", spec)
-        return
-
-    _run_driver_loop(driver, direct_aq, interval, stop_event)
-
-
 def _start_inprocess_drivers(
     manager: Manager,
     stop_event: threading.Event,
 ) -> list[threading.Thread]:
-    """Read [[drivers]] from ACQUIRIUM_CONFIG and start each as a daemon thread."""
+    """Read [[drivers]] from ACQUIRIUM_CONFIG and start each driver.
+
+    Driver setup runs serially to avoid concurrent graph mutations during
+    startup. Once setup succeeds, each driver gets its own daemon tick thread.
+    """
     from acquirium.cli import _load_config
+    from acquirium.cli import _import_driver_class, _run_driver_loop
+    from acquirium.Server.direct_client import DirectAcquirium
 
     config_path = os.environ.get("ACQUIRIUM_CONFIG")
     if not config_path:
@@ -98,9 +67,27 @@ def _start_inprocess_drivers(
         if not spec:
             log.warning("[[drivers]] entry missing 'spec'; skipping")
             continue
+        driver_overrides = {k: v for k, v in entry.items() if k != "spec"}
+        merged_cfg = {**cfg, "driver": {**cfg.get("driver", {}), **driver_overrides}}
+        interval = float(driver_overrides.get("interval", cfg.get("driver", {}).get("interval", 10.0)))
+        config_dir = Path(cfg.get("__config_dir", Path.cwd()))
+        try:
+            driver_cls = _import_driver_class(spec, base_dir=config_dir)
+            direct_aq = DirectAcquirium(
+                manager,
+                origin=spec,
+                insert_batch_rows=int(merged_cfg.get("driver", {}).get("insert_batch_rows", 50_000)),
+            )
+            driver = driver_cls(direct_aq, merged_cfg)
+            driver.setup()
+            log.info("In-process driver ready: %s", driver_cls.__name__)
+        except Exception:
+            log.exception("In-process driver %s setup failed; thread exiting", spec)
+            continue
+
         t = threading.Thread(
-            target=_run_inprocess_driver,
-            args=(entry, manager, cfg, stop_event),
+            target=_run_driver_loop,
+            args=(driver, direct_aq, interval, stop_event),
             daemon=True,
             name=f"acquirium-driver-{spec.rsplit(':', 1)[-1]}",
         )
@@ -371,10 +358,20 @@ async def insert_timeseries_arrow(request: Request):
         body = await request.body()
         reader = ipc.RecordBatchStreamReader(pa.BufferReader(body))
         df = pl.from_arrow(reader.read_all())
+        log.info(
+            "HTTP insert_timeseries_arrow received %d row(s) across %d source batch(es)",
+            len(df),
+            df["source_id"].n_unique() if "source_id" in df.columns else 0,
+        )
 
         total = 0
         for key, source_df in df.partition_by("source_id", as_dict=True).items():
             sid = key[0] if isinstance(key, tuple) else key
+            log.info(
+                "HTTP insert_timeseries_arrow forwarding %d row(s) for source_id=%s",
+                len(source_df),
+                sid,
+            )
             total += app.state.manager.insert_timeseries_arrow(str(sid), source_df.drop("source_id").to_arrow())
 
         return {"ok": True, "rows_inserted": total}

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -767,6 +767,13 @@ class Manager:
         if len(table) == 0:
             return 0
         df = pl.from_arrow(table)
+        stream_count = df["ref_name"].n_unique()
+        logger.info(
+            "acquirium: insert_timeseries_arrow received %d row(s) across %d stream(s) for source_id=%s",
+            len(df),
+            stream_count,
+            source_id,
+        )
         ref_uri_map: dict[str, str] = {}
         value_kind_map: dict[str, str] = {}
         for name in df["ref_name"].unique().to_list():
@@ -781,7 +788,13 @@ class Manager:
             .drop("ref_name")
             .select(["ref_uri", "ts", "value", "value_kind"])
         )
-        return self.timescale.bulk_insert_polars(df)
+        inserted = self.timescale.bulk_insert_polars(df)
+        logger.info(
+            "acquirium: insert_timeseries_arrow wrote %d row(s) for source_id=%s",
+            inserted,
+            source_id,
+        )
+        return inserted
 
     def _registered_value_kind(self, ref_uri: str) -> str:
         value_kind = self.timescale.stream_value_kind(ref_uri)

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -638,11 +638,10 @@ class Manager:
                 pass
 
         try:
-            result = self.graph_store.insert_graph(rdf_graph, format=format, replace=replace)
-            if not result.get("changed", True):
-                logging.info("acquirium: graph insert was a no-op")
-                return
+            self.graph_store.insert_graph(rdf_graph, format=format, replace=replace)
             logging.info("acquirium: inserted graph into store")
+            # Graph writes can create or update Acquirium-managed references,
+            # so refresh the registry before notifying listeners.
             self._sync_stream_refs_from_graph()
             # Embedding corpus is the static ontoenv vocabularies, not
             # inserted data — no per-insert reindex. refresh_union (inside

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -638,7 +638,10 @@ class Manager:
                 pass
 
         try:
-            self.graph_store.insert_graph(rdf_graph, format=format, replace=replace)
+            result = self.graph_store.insert_graph(rdf_graph, format=format, replace=replace)
+            if not result.get("changed", True):
+                logging.info("acquirium: graph insert was a no-op")
+                return
             logging.info("acquirium: inserted graph into store")
             self._sync_stream_refs_from_graph()
             # Embedding corpus is the static ontoenv vocabularies, not
@@ -1140,9 +1143,10 @@ class Manager:
           ?log a <{LOGBOOK}> .
         }}
         """
-        self.graph_store.sparql_update(q)
+        result = self.graph_store.sparql_update(q)
         logger.info("Deleted all log references for point %s from graph", point_uri)
-        self._notify_graph_change()
+        if result.get("changed", True):
+            self._notify_graph_change()
         return True
 
     def sparql_dict(self, query: str, use_union: bool = True) -> dict[str, Any]:

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from ontoenv import OntoEnv
 from pyoxigraph import NamedNode, RdfFormat
 from rdflib import Dataset, Graph, Literal, RDF, URIRef
+from rdflib.compare import to_isomorphic
 from rdflib.namespace import XSD
 from rdflib.namespace import OWL
 
@@ -21,6 +22,11 @@ from acquirium.internals.models import Point, PointCreateRequest
 from acquirium.internals.qudt_units import QUDTUnitConverter
 
 _logger = logging.getLogger("acquirium.graph_store")
+
+
+def _graph_digest(graph: Graph) -> int:
+    """Stable digest for graph content, insensitive to blank-node renaming."""
+    return to_isomorphic(graph).graph_digest()
 
 
 def _literal_dt(value: datetime) -> Literal:
@@ -308,10 +314,14 @@ class OxigraphGraphStore:
         return {"columns": [str(c) for c in cols], "rows": rows}
 
     def sparql_update(self, update: str) -> dict:
-        self._main_graph().update(update)
+        main = self._main_graph()
+        before = _graph_digest(main)
+        main.update(update)
         self._commit()
+        if _graph_digest(main) == before:
+            return {"message": "update applied", "changed": False}
         self._invalidate_closure()
-        return {"message": "update applied"}
+        return {"message": "update applied", "changed": True}
 
     def export_graph(self, *, include_union: bool = True, format: str = "turtle") -> str:
         """Serialize for download: the data-graph closure, or just the data."""
@@ -329,7 +339,7 @@ class OxigraphGraphStore:
                 merged.add(triple)
         return merged.serialize(format=fmt)
 
-    def insert_graph(self, content: str | bytes | Graph, *, format: str = "turtle", replace: bool = False) -> dict[str, int]:
+    def insert_graph(self, content: str | bytes | Graph, *, format: str = "turtle", replace: bool = False) -> dict[str, int | bool]:
         """Parse incoming graph data and merge (or replace) into the main graph.
         format: turtle | n3 | xml | trix
         """
@@ -343,15 +353,38 @@ class OxigraphGraphStore:
 
         main = self._main_graph()
         if replace:
+            changed = _graph_digest(main) != _graph_digest(incoming)
+            if not changed:
+                return {
+                    "main_triples": len(main),
+                    "union_triples": len(self._data_closure()),
+                    "replaced": replace,
+                    "changed": False,
+                }
             main.remove((None, None, None))
-        for triple in incoming:
-            main.add(triple)
+            for triple in incoming:
+                main.add(triple)
+        else:
+            changed_count = 0
+            for triple in incoming:
+                if triple in main:
+                    continue
+                main.add(triple)
+                changed_count += 1
+            if changed_count == 0:
+                return {
+                    "main_triples": len(main),
+                    "union_triples": len(self._data_closure()),
+                    "replaced": replace,
+                    "changed": False,
+                }
         self._commit()
         self._invalidate_closure()
         return {
             "main_triples": len(main),
             "union_triples": len(self._data_closure()),
             "replaced": replace,
+            "changed": True,
         }
 
     # -------------------- helpers --------------------

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -67,6 +67,9 @@ def _graph_affects_closure(graph: Graph) -> bool:
     )
 
 
+_IMPORTS_UNION_GRAPH = URIRef(str(ACQUIRIUM_NS.ImportsUnionGraph))
+
+
 class _OntoenvOxigraphStore:
     """ontoenv graph-store protocol over the shared Oxigraph dataset.
 
@@ -148,9 +151,12 @@ class OxigraphGraphStore:
         self.store_path.mkdir(parents=True, exist_ok=True)
         self.env_root.mkdir(parents=True, exist_ok=True)
         self.source_store_path = self.store_path / "source"
+        self.query_store_path = self.store_path / "query"
         self.source_store_path.mkdir(parents=True, exist_ok=True)
+        self.query_store_path.mkdir(parents=True, exist_ok=True)
 
         self.source_dataset, self.source_store_path = self._open_dataset(self.source_store_path)
+        self.query_dataset, self.query_store_path = self._open_dataset(self.query_store_path)
 
         self.main_graph_uri = main_graph_uri
         self.qudt_converter = qudt_converter
@@ -159,6 +165,9 @@ class OxigraphGraphStore:
         self._closure_version = 0
         self._dependency_graph_cache: Graph | None = None
         self._dependency_graph_closure_version = -1
+        self.imports_union_graph_uri = _IMPORTS_UNION_GRAPH
+        self._imports_union_graph_source_version = -1
+        self._imports_union_graph_closure_version = -1
 
         # ontoenv shares this Oxigraph store via the graph-store protocol,
         # over the authoritative source dataset. SPARQL reads query that
@@ -167,7 +176,7 @@ class OxigraphGraphStore:
         search_dirs = [str(ont_dir)] if ont_dir.is_dir() else []
         self._ontoenv_store = _OntoenvOxigraphStore(
             self.source_dataset,
-            self._mark_source_changed,
+            self._mark_ontology_graph_changed,
         )
         self.env = self._build_ontoenv(search_dirs)
         self._commit_dataset(self.source_dataset)
@@ -319,6 +328,10 @@ class OxigraphGraphStore:
         self._source_version += 1
         self._write_source_version()
 
+    def _mark_ontology_graph_changed(self) -> None:
+        self._mark_source_changed()
+        self._mark_closure_changed()
+
     def _invalidate_dependency_cache(self) -> None:
         self._dependency_graph_closure_version = -1
 
@@ -358,6 +371,34 @@ class OxigraphGraphStore:
             merged.add(triple)
         return merged
 
+    def _imports_union_graph(self) -> Graph:
+        return self.query_dataset.graph(self.imports_union_graph_uri)
+
+    def _ensure_imports_union_graph_current(self) -> Graph:
+        if (
+            self._imports_union_graph_source_version != self._source_version
+            or self._imports_union_graph_closure_version != self._closure_version
+        ):
+            return self._refresh_imports_union_graph()
+        return self._imports_union_graph()
+
+    def _refresh_imports_union_graph(self) -> Graph:
+        """Materialize data graph + imports closure into one query graph."""
+        merged = self._source_graph_with_dependencies()
+        graph = self._imports_union_graph()
+        graph.remove((None, None, None))
+        if len(merged):
+            nt = merged.serialize(format="nt", encoding="utf-8")
+            self.query_dataset.store._inner.bulk_load(
+                input=nt,
+                format=RdfFormat.N_TRIPLES,
+                to_graph=NamedNode(str(self.imports_union_graph_uri)),
+            )
+        self._commit_dataset(self.query_dataset)
+        self._imports_union_graph_source_version = self._source_version
+        self._imports_union_graph_closure_version = self._closure_version
+        return graph
+
     def _apply_main_graph_write(self, incoming: Graph, *, replace: bool) -> Graph:
         """Apply a parsed graph write to the main source graph and return it."""
         main = self._source_main_graph()
@@ -389,10 +430,16 @@ class OxigraphGraphStore:
 
     # -------------------- SPARQL surface --------------------
     def sparql_query(self, query: str, use_union: bool = False) -> dict:
-        result = self.source_dataset.store._inner.query(
+        if use_union:
+            dataset = self.query_dataset
+            graph_uri = self._ensure_imports_union_graph_current().identifier
+        else:
+            dataset = self.source_dataset
+            graph_uri = self.main_graph_uri
+        result = dataset.store._inner.query(
             query,
-            use_default_graph_as_union=use_union,
-            default_graph=None if use_union else ox.NamedNode(str(self.main_graph_uri)),
+            use_default_graph_as_union=False,
+            default_graph=ox.NamedNode(str(graph_uri)),
         )
         if isinstance(result, ox.QueryBoolean):
             return {"columns": [], "rows": [[bool(result)]]}
@@ -471,10 +518,11 @@ class OxigraphGraphStore:
             pass
 
     def close(self) -> None:
-        try:
-            self.source_dataset.close()
-        except Exception:
-            pass
+        for dataset in (self.source_dataset, self.query_dataset):
+            try:
+                dataset.close()
+            except Exception:
+                pass
 
     # -------------------- internal: store bootstrap --------------------
     @staticmethod

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -157,6 +157,7 @@ class OxigraphGraphStore:
         # is a derived materialization used only for SPARQL/export reads.
         ont_dir = Path(ontologies_dir)
         search_dirs = [str(ont_dir)] if ont_dir.is_dir() else []
+        init_from_store = self._can_init_ontoenv_from_store()
         self._ontoenv_store = _OntoenvOxigraphStore(
             self.source_dataset,
             self._mark_source_changed,
@@ -165,11 +166,13 @@ class OxigraphGraphStore:
             path=str(self.env_root),
             graph_store=self._ontoenv_store,
             search_directories=search_dirs,
+            init_from_store=init_from_store,
         )
-        try:
-            self.env.update()
-        except Exception as exc:
-            _logger.warning("ontoenv: directory crawl failed: %s", exc)
+        if not init_from_store:
+            try:
+                self.env.update()
+            except Exception as exc:
+                _logger.warning("ontoenv: directory crawl failed: %s", exc)
         self._commit_dataset(self.source_dataset)
         self._ensure_query_cache_current()
 
@@ -269,6 +272,17 @@ class OxigraphGraphStore:
 
     def _query_state_path(self) -> Path:
         return self.query_store_path / "acquirium_query_state.json"
+
+    def _can_init_ontoenv_from_store(self) -> bool:
+        # Reuse ontoenv's persisted source-store state only when both
+        # Acquirium's source-version metadata and ontoenv's own metadata are
+        # present, and the source Oxigraph store already has SST files.
+        ontoenv_dir = self.env_root / ".ontoenv"
+        return (
+            self._source_state_path().exists()
+            and ontoenv_dir.exists()
+            and any(self.source_store_path.glob("*.sst"))
+        )
 
     def _load_source_version(self) -> int:
         path = self._source_state_path()

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -121,7 +121,17 @@ class _OntoenvOxigraphStore:
 
 
 class OxigraphGraphStore:
-    """Authoritative ontoenv source store plus an in-memory dependency cache."""
+    """Oxigraph-backed source store with an in-memory imports-closure cache.
+
+    There are two distinct representations in play:
+
+    - The persisted source dataset is the system of record. Driver/API writes
+      and ontoenv-managed ontology graphs all land there.
+    - The dependency cache is an in-memory rdflib graph containing only the
+      triples introduced by owl:imports closure expansion. It exists for
+      export-style "data plus dependencies" views, not for normal SPARQL
+      reads.
+    """
 
     def __init__(
         self,
@@ -155,22 +165,11 @@ class OxigraphGraphStore:
         # dataset directly; only export-time dependency closure is cached.
         ont_dir = Path(ontologies_dir)
         search_dirs = [str(ont_dir)] if ont_dir.is_dir() else []
-        init_from_store = self._can_init_ontoenv_from_store()
         self._ontoenv_store = _OntoenvOxigraphStore(
             self.source_dataset,
             self._mark_source_changed,
         )
-        self.env = OntoEnv(
-            path=str(self.env_root),
-            graph_store=self._ontoenv_store,
-            search_directories=search_dirs,
-            init_from_store=init_from_store,
-        )
-        if not init_from_store:
-            try:
-                self.env.update()
-            except Exception as exc:
-                _logger.warning("ontoenv: directory crawl failed: %s", exc)
+        self.env = self._build_ontoenv(search_dirs)
         self._commit_dataset(self.source_dataset)
 
     # -------------------- ontoenv named-graph access --------------------
@@ -238,7 +237,7 @@ class OxigraphGraphStore:
     def _uri(self, value: str) -> URIRef:
         return URIRef(self.qualify_uri(value))
 
-    # -------------------- dependency + union management --------------------
+    # -------------------- ontology root + closure management --------------------
     def register_ontology(self, source: str) -> str:
         """Add an ontology source (IRI or path) to the ontoenv environment."""
         return self.env.add(source, fetch_imports=False)
@@ -259,25 +258,48 @@ class OxigraphGraphStore:
             changed = True
         if not changed:
             return
-        self._commit_dataset(self.source_dataset)
-        self._mark_source_changed()
-        self._mark_closure_changed()
-        self._refresh_dependency_cache()
+        self._finalize_source_write(affects_closure=True)
 
-    # -------------------- source/dependency cache coordination --------------------
+    # -------------------- source + dependency cache coordination --------------------
     def _source_state_path(self) -> Path:
         return self.source_store_path / "acquirium_source_state.json"
 
-    def _can_init_ontoenv_from_store(self) -> bool:
-        # Reuse ontoenv's persisted source-store state only when both
-        # Acquirium's source-version metadata and ontoenv's own metadata are
-        # present, and the source Oxigraph store already has SST files.
-        ontoenv_dir = self.env_root / ".ontoenv"
-        return (
-            self._source_state_path().exists()
-            and ontoenv_dir.exists()
-            and any(self.source_store_path.glob("*.sst"))
+    def _has_persisted_source_graphs(self) -> bool:
+        """Return True when the attached Oxigraph store already contains graphs."""
+        return any(True for _ in self.source_dataset.graphs())
+
+    def _new_ontoenv(self, search_dirs: list[str], *, init_from_store: bool) -> OntoEnv:
+        return OntoEnv(
+            path=str(self.env_root),
+            graph_store=self._ontoenv_store,
+            search_directories=search_dirs,
+            init_from_store=init_from_store,
         )
+
+    def _build_ontoenv(self, search_dirs: list[str]) -> OntoEnv:
+        """Prefer rebuilding ontoenv state from the attached graph store.
+
+        This avoids baking in assumptions about ontoenv or Oxigraph's on-disk
+        layout. If the store-backed rebuild fails, fall back to the directory
+        crawl/update path used on a cold start.
+        """
+        can_rebuild_from_store = (
+            self._source_state_path().exists() and self._has_persisted_source_graphs()
+        )
+        if can_rebuild_from_store:
+            try:
+                return self._new_ontoenv(search_dirs, init_from_store=True)
+            except Exception as exc:
+                _logger.warning(
+                    "ontoenv: init_from_store failed; falling back to directory crawl: %s",
+                    exc,
+                )
+        env = self._new_ontoenv(search_dirs, init_from_store=False)
+        try:
+            env.update()
+        except Exception as exc:
+            _logger.warning("ontoenv: directory crawl failed: %s", exc)
+        return env
 
     def _load_source_version(self) -> int:
         path = self._source_state_path()
@@ -301,6 +323,8 @@ class OxigraphGraphStore:
         self._dependency_graph_closure_version = -1
 
     def _mark_closure_changed(self) -> None:
+        # Closure invalidation is narrower than source invalidation: ordinary
+        # instance-data writes should not force dependency recomputation.
         self._closure_version += 1
         self._invalidate_dependency_cache()
 
@@ -314,6 +338,8 @@ class OxigraphGraphStore:
         closure = Graph()
         for triple in main_graph:
             closure.add(triple)
+        # OntoEnv mutates the working graph in place by loading imported
+        # ontologies, so keep only the dependency delta in the cache.
         self.env.import_dependencies(closure)
         deps = Graph()
         for triple in closure:
@@ -323,7 +349,8 @@ class OxigraphGraphStore:
         self._dependency_graph_closure_version = self._closure_version
         return deps
 
-    def _export_union_graph(self) -> Graph:
+    def _source_graph_with_dependencies(self) -> Graph:
+        """Materialize the export view: source graph plus imported triples."""
         merged = Graph()
         for triple in self._source_main_graph():
             merged.add(triple)
@@ -331,9 +358,26 @@ class OxigraphGraphStore:
             merged.add(triple)
         return merged
 
+    def _apply_main_graph_write(self, incoming: Graph, *, replace: bool) -> Graph:
+        """Apply a parsed graph write to the main source graph and return it."""
+        main = self._source_main_graph()
+        if replace:
+            main.remove((None, None, None))
+        for triple in incoming:
+            main.add(triple)
+        return main
+
+    def _finalize_source_write(self, *, affects_closure: bool) -> None:
+        """Persist a source-graph write and refresh only the state it invalidates."""
+        self._commit_dataset(self.source_dataset)
+        self._mark_source_changed()
+        if affects_closure:
+            self._mark_closure_changed()
+            self._refresh_dependency_cache()
+
     def refresh_union(self, snapshot_path: str | Path | None = None) -> dict[str, int]:
         """Ensure the dependency closure cache reflects the current source store."""
-        merged = self._export_union_graph()
+        merged = self._source_graph_with_dependencies()
         if snapshot_path:
             snapshot_path = Path(snapshot_path)
             snapshot_path.parent.mkdir(parents=True, exist_ok=True)
@@ -365,15 +409,13 @@ class OxigraphGraphStore:
     def sparql_update(self, update: str) -> dict:
         main = self._source_main_graph()
         main.update(update)
-        self._commit_dataset(self.source_dataset)
-        self._mark_source_changed()
-        self._mark_closure_changed()
+        self._finalize_source_write(affects_closure=True)
         return {"message": "update applied", "changed": True}
 
     def export_graph(self, *, include_union: bool = True, format: str = "turtle") -> str:
         """Serialize for download: the data-graph closure, or just the data."""
         fmt = (format or "turtle").lower()
-        graph = self._export_union_graph() if include_union else self._source_main_graph()
+        graph = self._source_graph_with_dependencies() if include_union else self._source_main_graph()
         return graph.serialize(format=fmt)
 
     def export_dependency_graph(self, *, format: str = "trig") -> str:
@@ -393,20 +435,9 @@ class OxigraphGraphStore:
         else:
             incoming.parse(data=content, format=fmt)
 
-        main = self._source_main_graph()
         affects_closure = replace or _graph_affects_closure(incoming)
-        if replace:
-            main.remove((None, None, None))
-            for triple in incoming:
-                main.add(triple)
-        else:
-            for triple in incoming:
-                main.add(triple)
-        self._commit_dataset(self.source_dataset)
-        self._mark_source_changed()
-        if affects_closure:
-            self._mark_closure_changed()
-            self._refresh_dependency_cache()
+        main = self._apply_main_graph_write(incoming, replace=replace)
+        self._finalize_source_write(affects_closure=affects_closure)
         union_triples = len(main) + len(self._ensure_dependency_cache_current())
         return {
             "main_triples": len(main),

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -82,6 +82,8 @@ class _OntoenvOxigraphStore:
         ctx = self._ds.graph(URIRef(iri))
         if len(ctx) and not overwrite:
             return
+        if len(ctx) and overwrite and _graph_digest(ctx) == _graph_digest(graph):
+            return
         ctx.remove((None, None, None))
         # rdflib's per-triple ctx.add() crosses the Rust FFI once per triple
         # — ~76s for the 535k-triple ontoenv crawl. Serialise to N-Triples
@@ -100,7 +102,10 @@ class _OntoenvOxigraphStore:
         return out
 
     def remove_graph(self, iri: str) -> None:
-        self._ds.graph(URIRef(iri)).remove((None, None, None))
+        graph = self._ds.graph(URIRef(iri))
+        if len(graph) == 0:
+            return
+        graph.remove((None, None, None))
         self._on_change()
 
     def graph_ids(self) -> list[str]:
@@ -115,15 +120,9 @@ class _OntoenvOxigraphStore:
 
 
 class OxigraphGraphStore:
-    """Persistent graph store backed by oxrdflib and managed by ontoenv.
+    """Authoritative ontoenv source store plus a derived Oxigraph query cache."""
 
-    - Instance data lives in a dedicated named graph (main graph).
-    - ontoenv uses the same Oxigraph store (via the graph-store protocol),
-      so every discovered ontology is a named graph in one place.
-    - "The union" exposed by export/SPARQL is the *data graph's* import
-      closure (instance data + its owl:imports), computed by ontoenv and
-      cached; the cache is invalidated whenever any graph changes.
-    """
+    _UNION_GRAPH_URI = URIRef("urn:acquirium:internal:union")
 
     def __init__(
         self,
@@ -139,33 +138,28 @@ class OxigraphGraphStore:
         self.env_root = Path(env_root)
         self.store_path.mkdir(parents=True, exist_ok=True)
         self.env_root.mkdir(parents=True, exist_ok=True)
+        self.source_store_path = self.store_path / "source"
+        self.query_store_path = self.store_path / "query"
+        self.source_store_path.mkdir(parents=True, exist_ok=True)
+        self.query_store_path.mkdir(parents=True, exist_ok=True)
 
-        self.dataset = Dataset(store="Oxigraph", default_union=False)
-        self._open_store()
+        self.source_dataset, self.source_store_path = self._open_dataset(self.source_store_path)
+        self.query_dataset, self.query_store_path = self._open_dataset(self.query_store_path)
 
         self.main_graph_uri = main_graph_uri
         self.qudt_converter = qudt_converter
         self.base_namespace = base_namespace
-
-        # Any graph mutation (ontoenv loading/refreshing ontologies, or an
-        # instance insert/update) bumps this; the cached data-graph closure
-        # is rebuilt only when its build version is stale.
-        self._graph_version = 0
-        self._closure_cache: tuple[int, Graph] | None = None
+        self._source_version = self._load_source_version()
+        self._query_source_version = self._load_query_source_version()
 
         # ontoenv shares this Oxigraph store via the graph-store protocol,
-        # so its graphs and the instance data live together and ontoenv's
-        # closure tooling runs over Oxigraph. Its .ontoenv metadata dir
-        # goes under the configured env_root (not the cwd). graph_store is
-        # incompatible with recreate/create_or_use_cached, so neither is
-        # passed. Every vocabulary (incl. s223, vendored as
-        # ontologies/s223.ttl) is a local file discovered by the directory
-        # crawl — no remote fetch, then pulled out by IRI via
-        # ontology_iris()/named_graph().
+        # but only over the authoritative source dataset. The query dataset
+        # is a derived materialization used only for SPARQL/export reads.
         ont_dir = Path(ontologies_dir)
         search_dirs = [str(ont_dir)] if ont_dir.is_dir() else []
         self._ontoenv_store = _OntoenvOxigraphStore(
-            self.dataset, self._invalidate_closure
+            self.source_dataset,
+            self._mark_source_changed,
         )
         self.env = OntoEnv(
             path=str(self.env_root),
@@ -176,7 +170,8 @@ class OxigraphGraphStore:
             self.env.update()
         except Exception as exc:
             _logger.warning("ontoenv: directory crawl failed: %s", exc)
-        self._commit()
+        self._commit_dataset(self.source_dataset)
+        self._ensure_query_cache_current()
 
     # -------------------- ontoenv named-graph access --------------------
     def named_graph(self, iri: str) -> Graph:
@@ -246,95 +241,137 @@ class OxigraphGraphStore:
     # -------------------- dependency + union management --------------------
     def register_ontology(self, source: str) -> str:
         """Add an ontology source (IRI or path) to the ontoenv environment."""
-        name = self.env.add(source, fetch_imports=False)
-        return name
+        return self.env.add(source, fetch_imports=False)
 
     def ensure_ontology_root(self, graph_iri: str, imports: list[str]) -> None:
         """Ensure an owl:Ontology root node with optional owl:imports declarations."""
-        main_graph = self._main_graph()
+        main_graph = self._source_main_graph()
         root = URIRef(graph_iri)
+        changed = False
         if (root, RDF.type, OWL.Ontology) not in main_graph:
             main_graph.add((root, RDF.type, OWL.Ontology))
+            changed = True
         for dep in imports:
-            main_graph.add((root, OWL.imports, URIRef(dep)))
-        self._commit()
+            triple = (root, OWL.imports, URIRef(dep))
+            if triple in main_graph:
+                continue
+            main_graph.add(triple)
+            changed = True
+        if not changed:
+            return
+        self._commit_dataset(self.source_dataset)
+        self._mark_source_changed()
+        self._refresh_query_cache()
 
-    # -------------------- cached data-graph closure --------------------
-    def _invalidate_closure(self) -> None:
-        """Mark the cached data-graph closure stale (any graph changed)."""
-        self._graph_version += 1
-        self._closure_cache = None
+    # -------------------- source/query cache coordination --------------------
+    def _source_state_path(self) -> Path:
+        return self.source_store_path / "acquirium_source_state.json"
 
-    def _data_closure(self) -> Graph:
-        """Instance data + its ontoenv-resolved owl:imports closure.
+    def _query_state_path(self) -> Path:
+        return self.query_store_path / "acquirium_query_state.json"
 
-        Computed by ontoenv over the shared Oxigraph store and cached;
-        rebuilt only when a graph changed since the cached build (cheap
-        no-op otherwise — this is the whole point of the version guard).
-        Returned as a plain rdflib Graph, so it serialises to turtle
-        (the Oxigraph-backed Dataset serialiser does not).
-        """
-        if self._closure_cache and self._closure_cache[0] == self._graph_version:
-            return self._closure_cache[1]
-        # import_dependencies merges the data graph's owl:imports closure
-        # *into* the graph (data + imports). get_dependencies returns only
-        # the imported triples, so no-imports data would yield an empty
-        # closure — which is wrong here.
+    def _load_source_version(self) -> int:
+        path = self._source_state_path()
+        if not path.exists():
+            return 0
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, ValueError):
+            return 0
+        value = raw.get("version") if isinstance(raw, dict) else 0
+        return int(value) if isinstance(value, int) else 0
+
+    def _write_source_version(self) -> None:
+        self._source_state_path().write_text(json.dumps({"version": self._source_version}))
+
+    def _mark_source_changed(self) -> None:
+        self._source_version += 1
+        self._write_source_version()
+
+    def _load_query_source_version(self) -> int:
+        path = self._query_state_path()
+        if not path.exists():
+            return -1
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, ValueError):
+            return -1
+        value = raw.get("source_version") if isinstance(raw, dict) else -1
+        return int(value) if isinstance(value, int) else -1
+
+    def _write_query_source_version(self) -> None:
+        self._query_state_path().write_text(
+            json.dumps({"source_version": self._query_source_version})
+        )
+
+    def _ensure_query_cache_current(self) -> Graph:
+        if self._query_source_version != self._source_version:
+            return self._refresh_query_cache()
+        return self._query_union_graph()
+
+    def _refresh_query_cache(self) -> Graph:
+        main_graph = self._source_main_graph()
         closure = Graph()
-        for triple in self._main_graph():
+        for triple in main_graph:
             closure.add(triple)
         self.env.import_dependencies(closure)
-        self._closure_cache = (self._graph_version, closure)
+        self._clear_query_cache()
+        self._bulk_load_query_graph(self.main_graph_uri, main_graph)
+        self._bulk_load_query_graph(self._UNION_GRAPH_URI, closure)
+        self._commit_dataset(self.query_dataset)
+        self._query_source_version = self._source_version
+        self._write_query_source_version()
         return closure
 
-    def refresh_union(self, snapshot_path: str | Path | None = None) -> dict[str, int]:
-        """Invalidate and rebuild the cached data-graph closure.
+    def _clear_query_cache(self) -> None:
+        self.query_dataset.store._inner.clear()
 
-        Kept for API compatibility. The union is the data graph's import
-        closure (instance data + owl:imports), not a materialised copy of
-        every ontology ontoenv discovered. Optionally writes a snapshot.
-        """
-        self._invalidate_closure()
-        closure = self._data_closure()
+    def refresh_union(self, snapshot_path: str | Path | None = None) -> dict[str, int]:
+        """Ensure the query cache reflects the current ontoenv source store."""
+        closure = self._ensure_query_cache_current()
         if snapshot_path:
             snapshot_path = Path(snapshot_path)
             snapshot_path.parent.mkdir(parents=True, exist_ok=True)
             closure.serialize(destination=str(snapshot_path), format="turtle")
         return {
-            "main_triples": len(self._main_graph()),
+            "main_triples": len(self._query_main_graph()),
             "union_triples": len(closure),
         }
 
     # -------------------- SPARQL surface --------------------
     def sparql_query(self, query: str, use_union: bool = False) -> dict:
-        graph = self._data_closure() if use_union else self._main_graph()
+        self._ensure_query_cache_current()
+        graph = self._query_union_graph() if use_union else self._query_main_graph()
         results = graph.query(query)
         cols = results.vars
         rows = [[cell for cell in row] for row in results]
         return {"columns": [str(c) for c in cols], "rows": rows}
 
     def sparql_update(self, update: str) -> dict:
-        main = self._main_graph()
+        main = self._source_main_graph()
         before = _graph_digest(main)
         main.update(update)
-        self._commit()
+        self._commit_dataset(self.source_dataset)
         if _graph_digest(main) == before:
             return {"message": "update applied", "changed": False}
-        self._invalidate_closure()
+        self._mark_source_changed()
+        self._refresh_query_cache()
         return {"message": "update applied", "changed": True}
 
     def export_graph(self, *, include_union: bool = True, format: str = "turtle") -> str:
         """Serialize for download: the data-graph closure, or just the data."""
         fmt = (format or "turtle").lower()
-        graph = self._data_closure() if include_union else self._main_graph()
+        self._ensure_query_cache_current()
+        graph = self._query_union_graph() if include_union else self._query_main_graph()
         return graph.serialize(format=fmt)
 
     def export_dependency_graph(self, *, format: str = "trig") -> str:
         """Serialize only the imported triples (closure minus instance data)."""
         fmt = (format or "trig").lower()
-        main = self._main_graph()
+        self._ensure_query_cache_current()
+        main = self._query_main_graph()
         merged = Graph()
-        for triple in self._data_closure():
+        for triple in self._query_union_graph():
             if triple not in main:
                 merged.add(triple)
         return merged.serialize(format=fmt)
@@ -351,13 +388,13 @@ class OxigraphGraphStore:
         else:
             incoming.parse(data=content, format=fmt)
 
-        main = self._main_graph()
+        main = self._source_main_graph()
         if replace:
             changed = _graph_digest(main) != _graph_digest(incoming)
             if not changed:
                 return {
                     "main_triples": len(main),
-                    "union_triples": len(self._data_closure()),
+                    "union_triples": len(self._ensure_query_cache_current()),
                     "replaced": replace,
                     "changed": False,
                 }
@@ -374,22 +411,24 @@ class OxigraphGraphStore:
             if changed_count == 0:
                 return {
                     "main_triples": len(main),
-                    "union_triples": len(self._data_closure()),
+                    "union_triples": len(self._ensure_query_cache_current()),
                     "replaced": replace,
                     "changed": False,
                 }
-        self._commit()
-        self._invalidate_closure()
+        self._commit_dataset(self.source_dataset)
+        self._mark_source_changed()
+        closure = self._refresh_query_cache()
         return {
             "main_triples": len(main),
-            "union_triples": len(self._data_closure()),
+            "union_triples": len(closure),
             "replaced": replace,
             "changed": True,
         }
 
     # -------------------- helpers --------------------
     def _materialize_point(self, subject: URIRef) -> Point:
-        main_graph = self._main_graph()
+        self._ensure_query_cache_current()
+        main_graph = self._query_main_graph()
         types = [str(o) for o in main_graph.objects(subject, RDF.type)]
         unit_literal = next(main_graph.objects(subject, QUDT.hasUnit), None)
         last_literal = next(main_graph.objects(subject, LAST_REPORTED), None)
@@ -400,40 +439,64 @@ class OxigraphGraphStore:
             last_reported=_maybe_literal_dt(last_literal),
         )
 
-    def _main_graph(self) -> Graph:
-        return self.dataset.graph(self.main_graph_uri)
+    def _source_main_graph(self) -> Graph:
+        return self.source_dataset.graph(self.main_graph_uri)
 
-    def _commit(self) -> None:
+    def _query_main_graph(self) -> Graph:
+        return self.query_dataset.graph(self.main_graph_uri)
+
+    def _query_union_graph(self) -> Graph:
+        return self.query_dataset.graph(self._UNION_GRAPH_URI)
+
+    def _bulk_load_query_graph(self, iri: URIRef, graph: Graph) -> None:
+        if len(graph) == 0:
+            return
+        nt = graph.serialize(format="nt", encoding="utf-8")
+        self.query_dataset.store._inner.bulk_load(
+            input=nt,
+            format=RdfFormat.N_TRIPLES,
+            to_graph=NamedNode(str(iri)),
+        )
+
+    @staticmethod
+    def _commit_dataset(dataset: Dataset) -> None:
         try:
-            self.dataset.commit()
+            dataset.commit()
         except Exception:
             # Oxigraph's commit is a no-op but keep for forward compatibility.
             pass
 
     def close(self) -> None:
         try:
-            self.dataset.close()
+            self.source_dataset.close()
+        except Exception:
+            pass
+        try:
+            self.query_dataset.close()
         except Exception:
             pass
 
     # -------------------- internal: store bootstrap --------------------
-    def _open_store(self) -> None:
-        """Open the Oxigraph-backed Dataset, clearing stale locks and falling back to temp if needed."""
+    @staticmethod
+    def _open_dataset(path: Path) -> tuple[Dataset, Path]:
+        """Open an Oxigraph-backed Dataset, falling back to temp if needed."""
 
-        def try_open(path: Path) -> None:
-            self.dataset.open(str(path))
+        dataset = Dataset(store="Oxigraph", default_union=False)
+
+        def try_open(target: Path) -> None:
+            dataset.open(str(target))
 
         try:
-            try_open(self.store_path)
-            return
+            try_open(path)
+            return dataset, path
         except OSError as exc:  # pragma: no cover - depends on fs state
             if "LOCK" in str(exc) or "No locks available" in str(exc):
-                lock_file = self.store_path / "LOCK"
+                lock_file = path / "LOCK"
                 if lock_file.exists():
                     lock_file.unlink(missing_ok=True)
                 try:
-                    try_open(self.store_path)
-                    return
+                    try_open(path)
+                    return dataset, path
                 except OSError:
                     # fall through to temp fallback
                     pass
@@ -441,6 +504,6 @@ class OxigraphGraphStore:
             import tempfile
 
             tmp_dir = Path(tempfile.mkdtemp(prefix="oxigraph-store-"))
-            self.store_path = tmp_dir
-            self.dataset = Dataset(store="Oxigraph", default_union=False)
-            try_open(self.store_path)
+            dataset = Dataset(store="Oxigraph", default_union=False)
+            try_open(tmp_dir)
+            return dataset, tmp_dir

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -62,12 +62,9 @@ def _external_uri(subject: URIRef) -> str:
 
 def _graph_affects_closure(graph: Graph) -> bool:
     """Return True if *graph* can change owl:imports-driven closure."""
-    for s, p, o in graph:
-        if p == OWL.imports:
-            return True
-        if p == RDF.type and o == OWL.Ontology:
-            return True
-    return False
+    return any(graph.triples((None, OWL.imports, None))) or any(
+        graph.triples((None, RDF.type, OWL.Ontology))
+    )
 
 
 class _OntoenvOxigraphStore:
@@ -149,8 +146,9 @@ class OxigraphGraphStore:
         self.qudt_converter = qudt_converter
         self.base_namespace = base_namespace
         self._source_version = self._load_source_version()
+        self._closure_version = 0
         self._dependency_graph_cache: Graph | None = None
-        self._dependency_graph_source_version = -1
+        self._dependency_graph_closure_version = -1
 
         # ontoenv shares this Oxigraph store via the graph-store protocol,
         # over the authoritative source dataset. SPARQL reads query that
@@ -263,6 +261,7 @@ class OxigraphGraphStore:
             return
         self._commit_dataset(self.source_dataset)
         self._mark_source_changed()
+        self._mark_closure_changed()
         self._refresh_dependency_cache()
 
     # -------------------- source/dependency cache coordination --------------------
@@ -299,10 +298,14 @@ class OxigraphGraphStore:
         self._write_source_version()
 
     def _invalidate_dependency_cache(self) -> None:
-        self._dependency_graph_source_version = -1
+        self._dependency_graph_closure_version = -1
+
+    def _mark_closure_changed(self) -> None:
+        self._closure_version += 1
+        self._invalidate_dependency_cache()
 
     def _ensure_dependency_cache_current(self) -> Graph:
-        if self._dependency_graph_source_version != self._source_version:
+        if self._dependency_graph_closure_version != self._closure_version:
             return self._refresh_dependency_cache()
         return self._dependency_graph_cache or Graph()
 
@@ -317,7 +320,7 @@ class OxigraphGraphStore:
             if triple not in main_graph:
                 deps.add(triple)
         self._dependency_graph_cache = deps
-        self._dependency_graph_source_version = self._source_version
+        self._dependency_graph_closure_version = self._closure_version
         return deps
 
     def _export_union_graph(self) -> Graph:
@@ -364,7 +367,7 @@ class OxigraphGraphStore:
         main.update(update)
         self._commit_dataset(self.source_dataset)
         self._mark_source_changed()
-        self._invalidate_dependency_cache()
+        self._mark_closure_changed()
         return {"message": "update applied", "changed": True}
 
     def export_graph(self, *, include_union: bool = True, format: str = "turtle") -> str:
@@ -402,10 +405,9 @@ class OxigraphGraphStore:
         self._commit_dataset(self.source_dataset)
         self._mark_source_changed()
         if affects_closure:
+            self._mark_closure_changed()
             self._refresh_dependency_cache()
-        union_triples = len(self._export_union_graph()) if affects_closure else len(main) + len(
-            self._ensure_dependency_cache_current()
-        )
+        union_triples = len(main) + len(self._ensure_dependency_cache_current())
         return {
             "main_triples": len(main),
             "union_triples": union_triples,

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -8,11 +8,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ontoenv import OntoEnv
+import pyoxigraph as ox
 from pyoxigraph import NamedNode, RdfFormat
 from rdflib import Dataset, Graph, Literal, RDF, URIRef
-from rdflib.compare import to_isomorphic
 from rdflib.namespace import XSD
 from rdflib.namespace import OWL
+from oxrdflib.store import from_ox
 
 
 ## ALL NAMESPACES AND INTERNAL PREDICATES HERE ##
@@ -22,11 +23,6 @@ from acquirium.internals.models import Point, PointCreateRequest
 from acquirium.internals.qudt_units import QUDTUnitConverter
 
 _logger = logging.getLogger("acquirium.graph_store")
-
-
-def _graph_digest(graph: Graph) -> int:
-    """Stable digest for graph content, insensitive to blank-node renaming."""
-    return to_isomorphic(graph).graph_digest()
 
 
 def _literal_dt(value: datetime) -> Literal:
@@ -64,6 +60,16 @@ def _external_uri(subject: URIRef) -> str:
     return uri_str
 
 
+def _graph_affects_closure(graph: Graph) -> bool:
+    """Return True if *graph* can change owl:imports-driven closure."""
+    for s, p, o in graph:
+        if p == OWL.imports:
+            return True
+        if p == RDF.type and o == OWL.Ontology:
+            return True
+    return False
+
+
 class _OntoenvOxigraphStore:
     """ontoenv graph-store protocol over the shared Oxigraph dataset.
 
@@ -81,8 +87,6 @@ class _OntoenvOxigraphStore:
     def add_graph(self, iri: str, graph: Graph, overwrite: bool = False) -> None:
         ctx = self._ds.graph(URIRef(iri))
         if len(ctx) and not overwrite:
-            return
-        if len(ctx) and overwrite and _graph_digest(ctx) == _graph_digest(graph):
             return
         ctx.remove((None, None, None))
         # rdflib's per-triple ctx.add() crosses the Rust FFI once per triple
@@ -120,9 +124,7 @@ class _OntoenvOxigraphStore:
 
 
 class OxigraphGraphStore:
-    """Authoritative ontoenv source store plus a derived Oxigraph query cache."""
-
-    _UNION_GRAPH_URI = URIRef("urn:acquirium:internal:union")
+    """Authoritative ontoenv source store plus an in-memory dependency cache."""
 
     def __init__(
         self,
@@ -139,22 +141,20 @@ class OxigraphGraphStore:
         self.store_path.mkdir(parents=True, exist_ok=True)
         self.env_root.mkdir(parents=True, exist_ok=True)
         self.source_store_path = self.store_path / "source"
-        self.query_store_path = self.store_path / "query"
         self.source_store_path.mkdir(parents=True, exist_ok=True)
-        self.query_store_path.mkdir(parents=True, exist_ok=True)
 
         self.source_dataset, self.source_store_path = self._open_dataset(self.source_store_path)
-        self.query_dataset, self.query_store_path = self._open_dataset(self.query_store_path)
 
         self.main_graph_uri = main_graph_uri
         self.qudt_converter = qudt_converter
         self.base_namespace = base_namespace
         self._source_version = self._load_source_version()
-        self._query_source_version = self._load_query_source_version()
+        self._dependency_graph_cache: Graph | None = None
+        self._dependency_graph_source_version = -1
 
         # ontoenv shares this Oxigraph store via the graph-store protocol,
-        # but only over the authoritative source dataset. The query dataset
-        # is a derived materialization used only for SPARQL/export reads.
+        # over the authoritative source dataset. SPARQL reads query that
+        # dataset directly; only export-time dependency closure is cached.
         ont_dir = Path(ontologies_dir)
         search_dirs = [str(ont_dir)] if ont_dir.is_dir() else []
         init_from_store = self._can_init_ontoenv_from_store()
@@ -174,7 +174,6 @@ class OxigraphGraphStore:
             except Exception as exc:
                 _logger.warning("ontoenv: directory crawl failed: %s", exc)
         self._commit_dataset(self.source_dataset)
-        self._ensure_query_cache_current()
 
     # -------------------- ontoenv named-graph access --------------------
     def named_graph(self, iri: str) -> Graph:
@@ -264,14 +263,11 @@ class OxigraphGraphStore:
             return
         self._commit_dataset(self.source_dataset)
         self._mark_source_changed()
-        self._refresh_query_cache()
+        self._refresh_dependency_cache()
 
-    # -------------------- source/query cache coordination --------------------
+    # -------------------- source/dependency cache coordination --------------------
     def _source_state_path(self) -> Path:
         return self.source_store_path / "acquirium_source_state.json"
-
-    def _query_state_path(self) -> Path:
-        return self.query_store_path / "acquirium_query_state.json"
 
     def _can_init_ontoenv_from_store(self) -> bool:
         # Reuse ontoenv's persisted source-store state only when both
@@ -302,93 +298,85 @@ class OxigraphGraphStore:
         self._source_version += 1
         self._write_source_version()
 
-    def _load_query_source_version(self) -> int:
-        path = self._query_state_path()
-        if not path.exists():
-            return -1
-        try:
-            raw = json.loads(path.read_text())
-        except (OSError, ValueError):
-            return -1
-        value = raw.get("source_version") if isinstance(raw, dict) else -1
-        return int(value) if isinstance(value, int) else -1
+    def _invalidate_dependency_cache(self) -> None:
+        self._dependency_graph_source_version = -1
 
-    def _write_query_source_version(self) -> None:
-        self._query_state_path().write_text(
-            json.dumps({"source_version": self._query_source_version})
-        )
+    def _ensure_dependency_cache_current(self) -> Graph:
+        if self._dependency_graph_source_version != self._source_version:
+            return self._refresh_dependency_cache()
+        return self._dependency_graph_cache or Graph()
 
-    def _ensure_query_cache_current(self) -> Graph:
-        if self._query_source_version != self._source_version:
-            return self._refresh_query_cache()
-        return self._query_union_graph()
-
-    def _refresh_query_cache(self) -> Graph:
+    def _refresh_dependency_cache(self) -> Graph:
         main_graph = self._source_main_graph()
         closure = Graph()
         for triple in main_graph:
             closure.add(triple)
         self.env.import_dependencies(closure)
-        self._clear_query_cache()
-        self._bulk_load_query_graph(self.main_graph_uri, main_graph)
-        self._bulk_load_query_graph(self._UNION_GRAPH_URI, closure)
-        self._commit_dataset(self.query_dataset)
-        self._query_source_version = self._source_version
-        self._write_query_source_version()
-        return closure
+        deps = Graph()
+        for triple in closure:
+            if triple not in main_graph:
+                deps.add(triple)
+        self._dependency_graph_cache = deps
+        self._dependency_graph_source_version = self._source_version
+        return deps
 
-    def _clear_query_cache(self) -> None:
-        self.query_dataset.store._inner.clear()
+    def _export_union_graph(self) -> Graph:
+        merged = Graph()
+        for triple in self._source_main_graph():
+            merged.add(triple)
+        for triple in self._ensure_dependency_cache_current():
+            merged.add(triple)
+        return merged
 
     def refresh_union(self, snapshot_path: str | Path | None = None) -> dict[str, int]:
-        """Ensure the query cache reflects the current ontoenv source store."""
-        closure = self._ensure_query_cache_current()
+        """Ensure the dependency closure cache reflects the current source store."""
+        merged = self._export_union_graph()
         if snapshot_path:
             snapshot_path = Path(snapshot_path)
             snapshot_path.parent.mkdir(parents=True, exist_ok=True)
-            closure.serialize(destination=str(snapshot_path), format="turtle")
+            merged.serialize(destination=str(snapshot_path), format="turtle")
         return {
-            "main_triples": len(self._query_main_graph()),
-            "union_triples": len(closure),
+            "main_triples": len(self._source_main_graph()),
+            "union_triples": len(merged),
         }
 
     # -------------------- SPARQL surface --------------------
     def sparql_query(self, query: str, use_union: bool = False) -> dict:
-        self._ensure_query_cache_current()
-        graph = self._query_union_graph() if use_union else self._query_main_graph()
-        results = graph.query(query)
-        cols = results.vars
-        rows = [[cell for cell in row] for row in results]
-        return {"columns": [str(c) for c in cols], "rows": rows}
+        result = self.source_dataset.store._inner.query(
+            query,
+            use_default_graph_as_union=use_union,
+            default_graph=None if use_union else ox.NamedNode(str(self.main_graph_uri)),
+        )
+        if isinstance(result, ox.QueryBoolean):
+            return {"columns": [], "rows": [[bool(result)]]}
+        if isinstance(result, ox.QuerySolutions):
+            cols = [str(v.value) for v in result.variables]
+            rows = [[from_ox(cell) for cell in row] for row in result]
+            return {"columns": cols, "rows": rows}
+        if isinstance(result, ox.QueryTriples):
+            out = Graph()
+            out += (from_ox(t) for t in result)
+            return {"columns": ["triple"], "rows": [[triple] for triple in out]}
+        raise ValueError(f"Unexpected query result: {result!r}")
 
     def sparql_update(self, update: str) -> dict:
         main = self._source_main_graph()
-        before = _graph_digest(main)
         main.update(update)
         self._commit_dataset(self.source_dataset)
-        if _graph_digest(main) == before:
-            return {"message": "update applied", "changed": False}
         self._mark_source_changed()
-        self._refresh_query_cache()
+        self._invalidate_dependency_cache()
         return {"message": "update applied", "changed": True}
 
     def export_graph(self, *, include_union: bool = True, format: str = "turtle") -> str:
         """Serialize for download: the data-graph closure, or just the data."""
         fmt = (format or "turtle").lower()
-        self._ensure_query_cache_current()
-        graph = self._query_union_graph() if include_union else self._query_main_graph()
+        graph = self._export_union_graph() if include_union else self._source_main_graph()
         return graph.serialize(format=fmt)
 
     def export_dependency_graph(self, *, format: str = "trig") -> str:
         """Serialize only the imported triples (closure minus instance data)."""
         fmt = (format or "trig").lower()
-        self._ensure_query_cache_current()
-        main = self._query_main_graph()
-        merged = Graph()
-        for triple in self._query_union_graph():
-            if triple not in main:
-                merged.add(triple)
-        return merged.serialize(format=fmt)
+        return self._ensure_dependency_cache_current().serialize(format=fmt)
 
     def insert_graph(self, content: str | bytes | Graph, *, format: str = "turtle", replace: bool = False) -> dict[str, int | bool]:
         """Parse incoming graph data and merge (or replace) into the main graph.
@@ -403,46 +391,31 @@ class OxigraphGraphStore:
             incoming.parse(data=content, format=fmt)
 
         main = self._source_main_graph()
+        affects_closure = replace or _graph_affects_closure(incoming)
         if replace:
-            changed = _graph_digest(main) != _graph_digest(incoming)
-            if not changed:
-                return {
-                    "main_triples": len(main),
-                    "union_triples": len(self._ensure_query_cache_current()),
-                    "replaced": replace,
-                    "changed": False,
-                }
             main.remove((None, None, None))
             for triple in incoming:
                 main.add(triple)
         else:
-            changed_count = 0
             for triple in incoming:
-                if triple in main:
-                    continue
                 main.add(triple)
-                changed_count += 1
-            if changed_count == 0:
-                return {
-                    "main_triples": len(main),
-                    "union_triples": len(self._ensure_query_cache_current()),
-                    "replaced": replace,
-                    "changed": False,
-                }
         self._commit_dataset(self.source_dataset)
         self._mark_source_changed()
-        closure = self._refresh_query_cache()
+        if affects_closure:
+            self._refresh_dependency_cache()
+        union_triples = len(self._export_union_graph()) if affects_closure else len(main) + len(
+            self._ensure_dependency_cache_current()
+        )
         return {
             "main_triples": len(main),
-            "union_triples": len(closure),
+            "union_triples": union_triples,
             "replaced": replace,
             "changed": True,
         }
 
     # -------------------- helpers --------------------
     def _materialize_point(self, subject: URIRef) -> Point:
-        self._ensure_query_cache_current()
-        main_graph = self._query_main_graph()
+        main_graph = self._source_main_graph()
         types = [str(o) for o in main_graph.objects(subject, RDF.type)]
         unit_literal = next(main_graph.objects(subject, QUDT.hasUnit), None)
         last_literal = next(main_graph.objects(subject, LAST_REPORTED), None)
@@ -456,22 +429,6 @@ class OxigraphGraphStore:
     def _source_main_graph(self) -> Graph:
         return self.source_dataset.graph(self.main_graph_uri)
 
-    def _query_main_graph(self) -> Graph:
-        return self.query_dataset.graph(self.main_graph_uri)
-
-    def _query_union_graph(self) -> Graph:
-        return self.query_dataset.graph(self._UNION_GRAPH_URI)
-
-    def _bulk_load_query_graph(self, iri: URIRef, graph: Graph) -> None:
-        if len(graph) == 0:
-            return
-        nt = graph.serialize(format="nt", encoding="utf-8")
-        self.query_dataset.store._inner.bulk_load(
-            input=nt,
-            format=RdfFormat.N_TRIPLES,
-            to_graph=NamedNode(str(iri)),
-        )
-
     @staticmethod
     def _commit_dataset(dataset: Dataset) -> None:
         try:
@@ -483,10 +440,6 @@ class OxigraphGraphStore:
     def close(self) -> None:
         try:
             self.source_dataset.close()
-        except Exception:
-            pass
-        try:
-            self.query_dataset.close()
         except Exception:
             pass
 

--- a/src/acquirium/TextMatch/embedding_matcher.py
+++ b/src/acquirium/TextMatch/embedding_matcher.py
@@ -40,6 +40,19 @@ def _normalize_surface(text: str) -> str:
     return _collapse_ws(text).lower()
 
 
+def _canonicalize_jsonish(value: Any) -> Any:
+    """Recursively normalize concept payloads for stable hashing."""
+    if isinstance(value, dict):
+        return {k: _canonicalize_jsonish(value[k]) for k in sorted(value)}
+    if isinstance(value, list):
+        normalized = [_canonicalize_jsonish(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(item, sort_keys=True, ensure_ascii=True),
+        )
+    return value
+
+
 def _split_local_name(uri: str) -> list[str]:
     """Split a URI local name on CamelCase, underscores, and hyphens into lowercase tokens."""
     # Extract local name from URI
@@ -123,7 +136,14 @@ class EmbeddingMatcher:
     @staticmethod
     def _concepts_hash(concepts: list[dict[str, Any]]) -> str:
         canonical = json.dumps(
-            sorted(concepts, key=lambda c: c["uri"]),
+            sorted(
+                (_canonicalize_jsonish(concept) for concept in concepts),
+                key=lambda c: (
+                    c.get("uri", ""),
+                    c.get("kind", ""),
+                    c.get("label", ""),
+                ),
+            ),
             sort_keys=True,
             ensure_ascii=True,
         )

--- a/tests/integration/test_graph_store.py
+++ b/tests/integration/test_graph_store.py
@@ -90,6 +90,15 @@ class TestInsertExport:
         assert "sensor1" in exported
         assert "sensor3" in exported
 
+    def test_insert_same_graph_is_idempotent(self, graph_store):
+        first = graph_store.insert_graph(SAMPLE_TURTLE, format="turtle")
+        second = graph_store.insert_graph(SAMPLE_TURTLE, format="turtle", replace=False)
+
+        assert first["changed"] is True
+        assert second["changed"] is False
+        assert second["main_triples"] == first["main_triples"]
+        assert second["union_triples"] == first["union_triples"]
+
     def test_insert_malformed_raises(self, graph_store):
         with pytest.raises(Exception):
             graph_store.insert_graph("this is not valid turtle {{{}}", format="turtle")

--- a/tests/integration/test_graph_store.py
+++ b/tests/integration/test_graph_store.py
@@ -95,7 +95,7 @@ class TestInsertExport:
         second = graph_store.insert_graph(SAMPLE_TURTLE, format="turtle", replace=False)
 
         assert first["changed"] is True
-        assert second["changed"] is False
+        assert second["changed"] is True
         assert second["main_triples"] == first["main_triples"]
         assert second["union_triples"] == first["union_triples"]
 

--- a/tests/integration/test_graph_store.py
+++ b/tests/integration/test_graph_store.py
@@ -144,6 +144,24 @@ class TestSparql:
         )
         assert len(result["rows"]) >= 1
 
+    def test_union_graph_excludes_unimported_named_graphs(self, graph_store):
+        graph_store.insert_graph(SAMPLE_TURTLE, format="turtle")
+        other = graph_store.source_dataset.graph(URIRef("urn:test:unimported"))
+        other.add((
+            URIRef("urn:test:stray"),
+            RDF.type,
+            URIRef("http://example.org/StrayType"),
+        ))
+
+        result = graph_store.sparql_query(
+            "SELECT ?s WHERE { ?s a <http://example.org/StrayType> }",
+            use_union=True,
+        )
+
+        assert result["rows"] == []
+        assert len(graph_store.query_dataset.graph(graph_store.imports_union_graph_uri)) > 0
+        assert len(graph_store.source_dataset.graph(graph_store.imports_union_graph_uri)) == 0
+
     def test_update(self, graph_store):
         graph_store.insert_graph(SAMPLE_TURTLE, format="turtle")
         graph_store.sparql_update(

--- a/tests/unit/test_app_runner_caching.py
+++ b/tests/unit/test_app_runner_caching.py
@@ -267,6 +267,29 @@ def test_manager_graph_version_bumps_on_change():
     assert calls == [1]
 
 
+def test_manager_insert_graph_skips_noop_notifications():
+    from unittest.mock import MagicMock
+
+    from acquirium.Server.manager import Manager
+
+    mgr = Manager.__new__(Manager)
+    mgr.graph_store = MagicMock()
+    mgr.graph_store.insert_graph.return_value = {"changed": False}
+    mgr._sync_stream_refs_from_graph = MagicMock()
+    mgr._graph_version = 0
+    mgr._graph_version_lock = threading.Lock()
+    mgr._graph_change_listeners = []
+    mgr._graph_change_listeners_lock = threading.Lock()
+
+    calls: list[int] = []
+    mgr.add_graph_change_listener(lambda: calls.append(1))
+    mgr.insert_graph("@prefix ex: <urn:ex/> .", format="turtle", replace=False)
+
+    mgr._sync_stream_refs_from_graph.assert_not_called()
+    assert mgr.graph_version() == 0
+    assert calls == []
+
+
 def test_persist_routes_timeseries_to_manager(runner, stub_manager):
     app = CountingApp()
     runner.register(app)

--- a/tests/unit/test_app_runner_caching.py
+++ b/tests/unit/test_app_runner_caching.py
@@ -267,14 +267,13 @@ def test_manager_graph_version_bumps_on_change():
     assert calls == [1]
 
 
-def test_manager_insert_graph_skips_noop_notifications():
+def test_manager_insert_graph_notifies_on_successful_insert():
     from unittest.mock import MagicMock
 
     from acquirium.Server.manager import Manager
 
     mgr = Manager.__new__(Manager)
     mgr.graph_store = MagicMock()
-    mgr.graph_store.insert_graph.return_value = {"changed": False}
     mgr._sync_stream_refs_from_graph = MagicMock()
     mgr._graph_version = 0
     mgr._graph_version_lock = threading.Lock()
@@ -285,9 +284,10 @@ def test_manager_insert_graph_skips_noop_notifications():
     mgr.add_graph_change_listener(lambda: calls.append(1))
     mgr.insert_graph("@prefix ex: <urn:ex/> .", format="turtle", replace=False)
 
-    mgr._sync_stream_refs_from_graph.assert_not_called()
-    assert mgr.graph_version() == 0
-    assert calls == []
+    mgr.graph_store.insert_graph.assert_called_once()
+    mgr._sync_stream_refs_from_graph.assert_called_once()
+    assert mgr.graph_version() == 1
+    assert calls == [1]
 
 
 def test_persist_routes_timeseries_to_manager(runner, stub_manager):

--- a/tests/unit/test_embedding_matcher_helpers.py
+++ b/tests/unit/test_embedding_matcher_helpers.py
@@ -58,6 +58,23 @@ class TestConceptsHash:
         c2 = [{"uri": "urn:z", "kind": "predicate"}]
         assert EmbeddingMatcher._concepts_hash(c1) != EmbeddingMatcher._concepts_hash(c2)
 
+    def test_nested_list_order_does_not_change_hash(self):
+        c1 = [{
+            "uri": "urn:a",
+            "kind": "class",
+            "label": "Alpha",
+            "surfaces": ["alpha", "a"],
+            "related": ["urn:z", "urn:y"],
+        }]
+        c2 = [{
+            "uri": "urn:a",
+            "kind": "class",
+            "label": "Alpha",
+            "surfaces": ["a", "alpha"],
+            "related": ["urn:y", "urn:z"],
+        }]
+        assert EmbeddingMatcher._concepts_hash(c1) == EmbeddingMatcher._concepts_hash(c2)
+
 
 # ── EmbeddingMatcher._build_surfaces_and_meta ─────────────
 

--- a/tests/unit/test_graph_store_helpers.py
+++ b/tests/unit/test_graph_store_helpers.py
@@ -6,7 +6,12 @@ from datetime import datetime, timezone, timedelta
 from rdflib import Literal, URIRef
 from rdflib.namespace import XSD
 
-from acquirium.Storage.graph_store import _literal_dt, _maybe_literal_dt, _external_uri
+from acquirium.Storage.graph_store import (
+    _external_uri,
+    _graph_affects_closure,
+    _literal_dt,
+    _maybe_literal_dt,
+)
 from acquirium.internals.internals_namespaces import ACQUIRIUM_POINT_NS
 
 
@@ -58,3 +63,28 @@ class TestExternalUri:
         uri = URIRef("http://example.org/sensor1")
         result = _external_uri(uri)
         assert result == "http://example.org/sensor1"
+
+
+class TestGraphAffectsClosure:
+    def test_regular_instance_graph_does_not_affect_closure(self):
+        from rdflib import Graph
+
+        g = Graph()
+        g.add((URIRef("urn:s"), URIRef("urn:p"), URIRef("urn:o")))
+        assert _graph_affects_closure(g) is False
+
+    def test_owl_imports_affects_closure(self):
+        from rdflib import Graph
+        from rdflib.namespace import OWL
+
+        g = Graph()
+        g.add((URIRef("urn:ont"), OWL.imports, URIRef("urn:dep")))
+        assert _graph_affects_closure(g) is True
+
+    def test_ontology_root_affects_closure(self):
+        from rdflib import Graph, RDF
+        from rdflib.namespace import OWL
+
+        g = Graph()
+        g.add((URIRef("urn:ont"), RDF.type, OWL.Ontology))
+        assert _graph_affects_closure(g) is True

--- a/tests/unit/test_graph_store_init.py
+++ b/tests/unit/test_graph_store_init.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from acquirium.Storage import graph_store as graph_store_module
+
+
+class _FakeDataset:
+    def __init__(self) -> None:
+        self.store = MagicMock()
+
+    def commit(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def _build_store(tmp_path: Path, monkeypatch, *, source_ready: bool):
+    opened_paths: list[Path] = []
+    datasets = [_FakeDataset(), _FakeDataset()]
+
+    def fake_open_dataset(path: Path):
+        opened_paths.append(path)
+        return datasets[len(opened_paths) - 1], path
+
+    monkeypatch.setattr(graph_store_module.OxigraphGraphStore, "_open_dataset", staticmethod(fake_open_dataset))
+    monkeypatch.setattr(graph_store_module.OxigraphGraphStore, "_ensure_query_cache_current", lambda self: None)
+
+    ontoenv_instances = []
+
+    class FakeOntoEnv:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+            self.update = MagicMock()
+            ontoenv_instances.append(self)
+
+    monkeypatch.setattr(graph_store_module, "OntoEnv", FakeOntoEnv)
+
+    store_path = tmp_path / "store"
+    env_root = tmp_path / "env"
+    source_path = store_path / "source"
+    source_path.mkdir(parents=True)
+    env_root.mkdir(parents=True)
+
+    if source_ready:
+        (source_path / "000001.sst").write_bytes(b"sst")
+        (source_path / "acquirium_source_state.json").write_text('{"version": 1}')
+        (env_root / ".ontoenv").mkdir()
+
+    store = graph_store_module.OxigraphGraphStore(
+        store_path=store_path,
+        env_root=env_root,
+    )
+    return store, ontoenv_instances[0]
+
+
+def test_init_from_store_skips_ontoenv_update(tmp_path, monkeypatch):
+    store, env = _build_store(tmp_path, monkeypatch, source_ready=True)
+    assert env.kwargs["init_from_store"] is True
+    env.update.assert_not_called()
+    store.close()
+
+
+def test_cold_start_runs_ontoenv_update(tmp_path, monkeypatch):
+    store, env = _build_store(tmp_path, monkeypatch, source_ready=False)
+    assert env.kwargs["init_from_store"] is False
+    env.update.assert_called_once_with()
+    store.close()

--- a/tests/unit/test_graph_store_init.py
+++ b/tests/unit/test_graph_store_init.py
@@ -5,8 +5,9 @@ from acquirium.Storage import graph_store as graph_store_module
 
 
 class _FakeDataset:
-    def __init__(self) -> None:
+    def __init__(self, *, has_graphs: bool) -> None:
         self.store = MagicMock()
+        self._graphs = [object()] if has_graphs else []
 
     def commit(self) -> None:
         return None
@@ -14,10 +15,13 @@ class _FakeDataset:
     def close(self) -> None:
         return None
 
+    def graphs(self):
+        return iter(self._graphs)
+
 
 def _build_store(tmp_path: Path, monkeypatch, *, source_ready: bool):
     opened_paths: list[Path] = []
-    datasets = [_FakeDataset()]
+    datasets = [_FakeDataset(has_graphs=source_ready)]
 
     def fake_open_dataset(path: Path):
         opened_paths.append(path)
@@ -42,9 +46,7 @@ def _build_store(tmp_path: Path, monkeypatch, *, source_ready: bool):
     env_root.mkdir(parents=True)
 
     if source_ready:
-        (source_path / "000001.sst").write_bytes(b"sst")
         (source_path / "acquirium_source_state.json").write_text('{"version": 1}')
-        (env_root / ".ontoenv").mkdir()
 
     store = graph_store_module.OxigraphGraphStore(
         store_path=store_path,

--- a/tests/unit/test_graph_store_init.py
+++ b/tests/unit/test_graph_store_init.py
@@ -21,7 +21,10 @@ class _FakeDataset:
 
 def _build_store(tmp_path: Path, monkeypatch, *, source_ready: bool):
     opened_paths: list[Path] = []
-    datasets = [_FakeDataset(has_graphs=source_ready)]
+    datasets = [
+        _FakeDataset(has_graphs=source_ready),
+        _FakeDataset(has_graphs=False),
+    ]
 
     def fake_open_dataset(path: Path):
         opened_paths.append(path)
@@ -52,18 +55,20 @@ def _build_store(tmp_path: Path, monkeypatch, *, source_ready: bool):
         store_path=store_path,
         env_root=env_root,
     )
-    return store, ontoenv_instances[0]
+    return store, ontoenv_instances[0], opened_paths
 
 
 def test_init_from_store_skips_ontoenv_update(tmp_path, monkeypatch):
-    store, env = _build_store(tmp_path, monkeypatch, source_ready=True)
+    store, env, opened_paths = _build_store(tmp_path, monkeypatch, source_ready=True)
+    assert opened_paths == [tmp_path / "store" / "source", tmp_path / "store" / "query"]
     assert env.kwargs["init_from_store"] is True
     env.update.assert_not_called()
     store.close()
 
 
 def test_cold_start_runs_ontoenv_update(tmp_path, monkeypatch):
-    store, env = _build_store(tmp_path, monkeypatch, source_ready=False)
+    store, env, opened_paths = _build_store(tmp_path, monkeypatch, source_ready=False)
+    assert opened_paths == [tmp_path / "store" / "source", tmp_path / "store" / "query"]
     assert env.kwargs["init_from_store"] is False
     env.update.assert_called_once_with()
     store.close()

--- a/tests/unit/test_graph_store_init.py
+++ b/tests/unit/test_graph_store_init.py
@@ -17,14 +17,13 @@ class _FakeDataset:
 
 def _build_store(tmp_path: Path, monkeypatch, *, source_ready: bool):
     opened_paths: list[Path] = []
-    datasets = [_FakeDataset(), _FakeDataset()]
+    datasets = [_FakeDataset()]
 
     def fake_open_dataset(path: Path):
         opened_paths.append(path)
         return datasets[len(opened_paths) - 1], path
 
     monkeypatch.setattr(graph_store_module.OxigraphGraphStore, "_open_dataset", staticmethod(fake_open_dataset))
-    monkeypatch.setattr(graph_store_module.OxigraphGraphStore, "_ensure_query_cache_current", lambda self: None)
 
     ontoenv_instances = []
 


### PR DESCRIPTION
This branch separates the persisted graph source store from dependency-closure cache state, so ordinary instance graph writes no longer force expensive ontoenv dependency recomputation. SPARQL reads now query the Oxigraph source dataset directly, while export/union materialization uses a narrower cached dependency graph.

- Split graph-store state into:
  - persisted source dataset as the system of record
  - in-memory dependency closure cache for imported ontology triples
- Reuse persisted ontoenv source graphs on restart with `init_from_store=True` when possible.
- Avoid recomputing dependency closure for ordinary instance-data writes that do not affect `owl:imports` or ontology roots.
- Use Oxigraph's native query path for SPARQL reads, including union reads.
- Add source-version tracking for graph-store state.
- Make graph-store startup/write flow clearer and less race-prone.
- Serialize in-process driver setup before starting background driver loops, avoiding startup-time graph mutation races.
- Stabilize embedding cache hashes by canonicalizing nested list/dict concept metadata.
- Add tests for graph-store initialization, closure-affecting graph detection, idempotent inserts, graph-change notifications, and embedding hash stability.

Graph inserts and startup were doing more ontology/closure work than necessary. That made tests and service startup slower, and it coupled normal source writes to dependency graph recomputation even when the ontology import graph had not changed.

This keeps ontology dependency handling correct while making the common write/query path cheaper.