### PR TITLE
ship ontologies with pypi

### DIFF
--- a/acquirium.toml
+++ b/acquirium.toml
@@ -41,13 +41,16 @@ recreate = false
 # read_batch_size = 50000
 
 # ---------------------------------------------------------------------------
-# Vocabulary ontology IRIs used to build the text->URI embedding indexes.
-# These are the exact ontology IRIs ontoenv reads out of `ontologies/`:
+# Vocabulary ontology sources used to build the text->URI embedding indexes:
 #   - water + s223 graphs are merged into the class/predicate/substance index
 #   - unit and quantity_kind graphs each feed the QUDT index
-# Exact IRIs avoid the QUDT version sprawl ontoenv pulls via owl:imports
-# (qudt_unit.ttl pins 3.2.1). Omit this table to use these same built-in
-# defaults; override only if you vendor different ontology files.
+# Each value can be one of:
+#   * an IRI ontoenv already discovered in `ontologies/` (pure rename),
+#   * a local file path — its `?s a owl:Ontology` triple names the graph,
+#     and a same-IRI bundled default is replaced (not duplicated),
+#   * a remote IRI — ontoenv fetches it; failures fall back to the default.
+# Omit this table (or any key) to use the built-in defaults; partial
+# overrides are merged with defaults so unspecified slots still resolve.
 # ---------------------------------------------------------------------------
 [ontologies]
 water         = "urn:nawi-water-ontology"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,19 @@ acquirium = "acquirium.cli:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel.force-include]
+"ontologies" = "acquirium/ontologies"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/acquirium",
+    "ontologies",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "pyproject.toml",
+]
+
 [dependency-groups]
 dev = [
     "openpyxl>=3.1.5",

--- a/src/acquirium/Server/manager.py
+++ b/src/acquirium/Server/manager.py
@@ -13,6 +13,7 @@ from acquirium.Storage import (
     TimeseriesStore,
     create_timeseries_store,
 )
+from acquirium.Storage.graph_store import default_ontologies_dir
 from acquirium.Storage.values import normalize_value_kind
 from acquirium.internals.qudt_units import QUDTUnitConverter
 from acquirium.internals.models import LogEntry, Order, TimeIntervalModel, AppSpec, AppRunRequest, compute_ref_uri
@@ -166,7 +167,7 @@ class Manager:
             converter = QUDTUnitConverter(qudt_graph)
         if converter is None:
             # Auto-detect local QUDT unit ontology
-            _qudt_local = Path("ontologies/qudt_unit.ttl")
+            _qudt_local = default_ontologies_dir() / "qudt_unit.ttl"
             if _qudt_local.exists():
                 try:
                     converter = QUDTUnitConverter(str(_qudt_local))
@@ -1191,14 +1192,15 @@ class Manager:
         """Lazily initialize the QUDT converter if not already available."""
         if self.qudt_converter is not None:
             return self.qudt_converter
-        _qudt_local = Path("ontologies/qudt_unit.ttl")
+        _qudt_local = default_ontologies_dir() / "qudt_unit.ttl"
         if _qudt_local.exists():
             self.qudt_converter = QUDTUnitConverter(str(_qudt_local))
             logger.info("Lazily loaded QUDTUnitConverter from %s", _qudt_local)
             return self.qudt_converter
         raise ValueError(
-            "QUDT converter not available. Place ontologies/qudt_unit.ttl "
-            "in the working directory or pass qudt_graph to Manager."
+            "QUDT converter not available. Place qudt_unit.ttl in the "
+            "package's ontologies/ directory (or the CWD-relative "
+            "ontologies/) or pass qudt_graph to Manager."
         )
 
     def resolve_unit_info(self, identifier: str) -> dict[str, Any]:

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -5,6 +5,7 @@ import logging
 import os
 from collections.abc import Callable
 from datetime import datetime, timezone
+from importlib.resources import files
 from pathlib import Path
 
 from ontoenv import OntoEnv
@@ -29,15 +30,18 @@ def default_ontologies_dir() -> Path:
     """Resolve the directory of vendored ontology .ttl files.
 
     Tried in order:
-      1. `<site-packages>/acquirium/ontologies/` (built wheel layout —
-         populated by hatchling `force-include`).
-      2. `<repo-root>/ontologies/` walking up from this module — so an
-         editable install / source checkout works from any CWD.
+      1. `acquirium`'s package data via importlib.resources — the official
+         API for shipped resources; works for any install layout.
+      2. `<repo-root>/ontologies/` walking up from this module, for an
+         uninstalled source checkout.
       3. CWD-relative `ontologies/` as a last resort.
     """
-    packaged = Path(__file__).resolve().parent.parent / "ontologies"
-    if packaged.is_dir():
-        return packaged
+    try:
+        resource = files("acquirium") / "ontologies"
+        if resource.is_dir():
+            return Path(str(resource))
+    except (ModuleNotFoundError, FileNotFoundError):
+        pass
     for parent in Path(__file__).resolve().parents:
         candidate = parent / "ontologies"
         if candidate.is_dir():

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -216,6 +216,7 @@ class OxigraphGraphStore:
         )
         with timed_debug(_logger, "OntoEnv build env_root=%s search_dirs=%s", self.env_root, search_dirs):
             self.env = self._build_ontoenv(search_dirs)
+        self._effective_iri_map = self._process_ontology_overrides()
         self._commit_dataset(self.source_dataset)
         _logger.debug(
             "OxigraphGraphStore.__init__: ready (main_graph=%s, source_version=%d)",
@@ -231,7 +232,9 @@ class OxigraphGraphStore:
     # `ontologies/` (qudt_unit.ttl pins QUDT 3.1.5; qudt_qk.ttl uses the
     # version-agnostic quantitykind IRI). Exact match avoids the QUDT
     # version sprawl ontoenv pulls in via owl:imports. Overridable via the
-    # acquirium.toml `[ontologies]` table (cli.py -> ACQUIRIUM_ONTOLOGY_IRIS).
+    # acquirium.toml `[ontologies]` table (cli.py -> ACQUIRIUM_ONTOLOGY_IRIS):
+    # values may be a known IRI (pure rename), a path to a local ontology
+    # file, or a remote IRI ontoenv can fetch.
     _ONTOLOGY_IRIS = {
         "water": "urn:nawi-water-ontology",
         "s223": "http://data.ashrae.org/standard223/1.0/model/all",
@@ -240,38 +243,77 @@ class OxigraphGraphStore:
     }
 
     @classmethod
-    def _resolve_iri_map(cls) -> dict[str, str]:
-        """The configured logical-name -> IRI map (env override or default)."""
+    def _raw_iri_map(cls) -> dict[str, str]:
+        """Merged literal [ontologies] table: defaults overlaid by env."""
+        merged = dict(cls._ONTOLOGY_IRIS)
         raw = os.getenv("ACQUIRIUM_ONTOLOGY_IRIS")
-        if raw:
-            try:
-                data = json.loads(raw)
-                if isinstance(data, dict) and data:
-                    return {str(k): str(v) for k, v in data.items()}
-                _logger.warning(
-                    "ACQUIRIUM_ONTOLOGY_IRIS not a non-empty object; using defaults"
-                )
-            except ValueError as exc:
-                _logger.warning(
-                    "ACQUIRIUM_ONTOLOGY_IRIS invalid JSON (%s); using defaults", exc
-                )
-        return dict(cls._ONTOLOGY_IRIS)
+        if not raw:
+            return merged
+        try:
+            data = json.loads(raw)
+        except ValueError as exc:
+            _logger.warning(
+                "ACQUIRIUM_ONTOLOGY_IRIS invalid JSON (%s); using defaults", exc
+            )
+            return merged
+        if not isinstance(data, dict) or not data:
+            _logger.warning(
+                "ACQUIRIUM_ONTOLOGY_IRIS not a non-empty object; using defaults"
+            )
+            return merged
+        merged.update({str(k): str(v) for k, v in data.items()})
+        return merged
 
-    def ontology_iris(self) -> dict[str, str]:
-        """Logical name -> ontology IRI for the ontologies ontoenv discovered.
+    def _process_ontology_overrides(self) -> dict[str, str]:
+        """Resolve each [ontologies] value to an IRI present in the store.
 
-        Keys: ``water``, ``s223``, ``unit``, ``quantity_kind`` (a key is
-        absent if ontoenv did not register that exact IRI).
+        A value is one of:
+
+        * an IRI ontoenv already discovered (pure rename) — kept as-is;
+        * a local file path — parsed; the owl:Ontology IRI inside the file
+          becomes the effective IRI and the named graph is (re)populated
+          with that file's triples (same-IRI bundled defaults replaced);
+        * any other string — handed to ontoenv as a remote IRI to fetch.
+
+        On loader failure the bundled default IRI is restored if it points
+        at a populated named graph; otherwise the key is dropped.
         """
         try:
-            names = set(self.env.get_ontology_names())
+            known = set(self.env.get_ontology_names())
         except Exception as exc:
             _logger.warning("ontoenv: get_ontology_names failed: %s", exc)
-            return {}
+            known = set()
+
+        raw_map = self._raw_iri_map()
+        effective: dict[str, str] = {}
+        for name, value in raw_map.items():
+            if value in known:
+                effective[name] = value
+                continue
+            resolved = self.register_ontology(value)
+            if resolved:
+                effective[name] = resolved
+                continue
+            default_iri = self._ONTOLOGY_IRIS.get(name)
+            if default_iri and len(self.source_dataset.graph(URIRef(default_iri))) > 0:
+                _logger.info(
+                    "ontology override for %s: falling back to bundled default %s",
+                    name, default_iri,
+                )
+                effective[name] = default_iri
+        return effective
+
+    def ontology_iris(self) -> dict[str, str]:
+        """Logical name -> ontology IRI for ontologies present in the store.
+
+        Keys: ``water``, ``s223``, ``unit``, ``quantity_kind`` (a key is
+        absent if its named graph is empty — e.g. the user override
+        failed to load and no usable default exists).
+        """
         return {
             name: iri
-            for name, iri in self._resolve_iri_map().items()
-            if iri in names
+            for name, iri in self._effective_iri_map.items()
+            if len(self.source_dataset.graph(URIRef(iri))) > 0
         }
 
     def qualify_uri(self, value: str) -> str:

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -103,8 +103,14 @@ class _OntoenvOxigraphStore:
     def __init__(self, dataset: Dataset, on_change: Callable[[], None]) -> None:
         self._ds = dataset
         self._on_change = on_change
+        # Flips on for the duration of a single user-override registration so
+        # ontoenv's internal add_graph call replaces a same-IRI bundled
+        # default instead of silently skipping it. See register_ontology.
+        self._force_overwrite_next = False
 
     def add_graph(self, iri: str, graph: Graph, overwrite: bool = False) -> None:
+        if self._force_overwrite_next:
+            overwrite = True
         ctx = self._ds.graph(URIRef(iri))
         if len(ctx) and not overwrite:
             _logger.debug("add_graph skip (already populated): %s (%d triples)", iri, len(ctx))
@@ -282,9 +288,65 @@ class OxigraphGraphStore:
         return URIRef(self.qualify_uri(value))
 
     # -------------------- ontology root + closure management --------------------
-    def register_ontology(self, source: str) -> str:
-        """Add an ontology source (IRI or path) to the ontoenv environment."""
-        return self.env.add(source, fetch_imports=False)
+    def register_ontology(self, source: str) -> str | None:
+        """Add an ontology source (path or IRI), replacing same-IRI defaults.
+
+        Path: parsed with rdflib; the named-graph IRI is taken from the
+        file's ``?s a owl:Ontology`` triple. If that triple is missing the
+        source is skipped with a warning (we have no other way to identify
+        which named graph the contents should land in).
+
+        IRI: handed to ontoenv, which fetches it online. If the fetch
+        fails the source is skipped with an info-level log so the user
+        knows to download and pass the file path next time.
+
+        When the resolved IRI matches a bundled default the named graph
+        is replaced (not silently kept); different-IRI sources coexist as
+        separate named graphs. Returns the loaded IRI, or None if skipped.
+        """
+        source_path = Path(source)
+        is_path = source_path.exists() and source_path.is_file()
+
+        if is_path:
+            graph = Graph()
+            try:
+                graph.parse(str(source_path))
+            except Exception as exc:
+                _logger.warning(
+                    "ontology source: failed to parse %s: %s; skipping",
+                    source, exc,
+                )
+                return None
+            ontology_iri = next(graph.subjects(RDF.type, OWL.Ontology), None)
+            if ontology_iri is None:
+                _logger.warning(
+                    "ontology source: %s has no `?s a owl:Ontology` triple; "
+                    "skipping (cannot determine the named-graph IRI)",
+                    source,
+                )
+                return None
+            iri_str = str(ontology_iri)
+            self._ontoenv_store.add_graph(iri_str, graph, overwrite=True)
+            _logger.info(
+                "ontology source: loaded %s into <%s> (%d triples)",
+                source, iri_str, len(graph),
+            )
+            return iri_str
+
+        self._ontoenv_store._force_overwrite_next = True
+        try:
+            result = self.env.add(source, fetch_imports=False)
+            _logger.info("ontology source: loaded IRI %s", source)
+            return result
+        except Exception as exc:
+            _logger.info(
+                "ontology source: failed to fetch IRI %s (%s); skipping. "
+                "Download the ontology and pass the local file path instead.",
+                source, exc,
+            )
+            return None
+        finally:
+            self._ontoenv_store._force_overwrite_next = False
 
     def ensure_ontology_root(self, graph_iri: str, imports: list[str]) -> None:
         """Ensure an owl:Ontology root node with optional owl:imports declarations."""

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -25,6 +25,26 @@ from acquirium.internals._log import timed_debug
 _logger = logging.getLogger("acquirium.graph_store")
 
 
+def default_ontologies_dir() -> Path:
+    """Resolve the directory of vendored ontology .ttl files.
+
+    Tried in order:
+      1. `<site-packages>/acquirium/ontologies/` (built wheel layout —
+         populated by hatchling `force-include`).
+      2. `<repo-root>/ontologies/` walking up from this module — so an
+         editable install / source checkout works from any CWD.
+      3. CWD-relative `ontologies/` as a last resort.
+    """
+    packaged = Path(__file__).resolve().parent.parent / "ontologies"
+    if packaged.is_dir():
+        return packaged
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "ontologies"
+        if candidate.is_dir():
+            return candidate
+    return Path("ontologies")
+
+
 def _literal_dt(value: datetime) -> Literal:
     '''
     Convert a datetime to an XSD.dateTime Literal in UTC.
@@ -147,8 +167,10 @@ class OxigraphGraphStore:
         main_graph_uri: URIRef = DEFAULT_MAIN_GRAPH,
         qudt_converter: QUDTUnitConverter | None = None,
         base_namespace: str | None = None,
-        ontologies_dir: str | Path = "ontologies",
+        ontologies_dir: str | Path | None = None,
     ):
+        if ontologies_dir is None:
+            ontologies_dir = default_ontologies_dir()
         self.store_path = Path(store_path)
         self.env_root = Path(env_root)
         self.store_path.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_graph_store_init.py
+++ b/tests/unit/test_graph_store_init.py
@@ -18,6 +18,10 @@ class _FakeDataset:
     def graphs(self):
         return iter(self._graphs)
 
+    def graph(self, _name):
+        # Pretend every queried named graph is empty.
+        return MagicMock(__len__=lambda self: 0)
+
 
 def _build_store(tmp_path: Path, monkeypatch, *, source_ready: bool):
     opened_paths: list[Path] = []


### PR DESCRIPTION
This pull request improves how the package locates and includes ontology files (`.ttl` files) required for unit conversions, making the codebase more robust and compatible with different installation layouts (such as wheels, source checkouts, and editable installs). The most important changes are:

**Ontology Directory Resolution Improvements:**

* Added a new `default_ontologies_dir()` function in `graph_store.py` that determines the best location for ontology files by checking the package directory, parent directories, and finally the current working directory. This ensures that ontology files are found regardless of how the package is installed or run.
* Updated the `GraphStore` class to use the new `default_ontologies_dir()` function when the `ontologies_dir` argument is not provided, improving default behavior and reducing the risk of missing files.
* Changed `Server/manager.py` to use `default_ontologies_dir()` instead of a hardcoded path when searching for `qudt_unit.ttl`, making ontology file discovery more reliable. [[1]](diffhunk://#diff-687a134726d8f93f28375bf9a4e2ae15db75f6bfcc7a40bdc2bbde1ed50b5106R16) [[2]](diffhunk://#diff-687a134726d8f93f28375bf9a4e2ae15db75f6bfcc7a40bdc2bbde1ed50b5106L169-R170) [[3]](diffhunk://#diff-687a134726d8f93f28375bf9a4e2ae15db75f6bfcc7a40bdc2bbde1ed50b5106L1194-R1203)

**Packaging Improvements:**

* Updated `pyproject.toml` to ensure the `ontologies` directory is included in both built wheels and source distributions. This guarantees ontology files are available in all installation scenarios.