### PR TITLE
Transfer namespaces during graph insertion and improve client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ change in any release.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-29
+
 ### Added
 - Bundled default ontologies inside the `acquirium` package
   (`acquirium/_ontologies/`): NAWI Water, ASHRAE 223P, QUDT units +
@@ -25,14 +27,29 @@ change in any release.
   rewrite declared ontology IRI to the canonical key, replace any
   pre-existing graph at that IRI). Use this to override a bundled
   ontology with a different file or URL.
-- `tests/unit/test_bundled_ontologies.py` and
-  `tests/unit/test_embedding_cache.py`.
+- `AcquiriumClient.compact_uri` / `expand_uri` for round-tripping
+  between full URIs and `prefix:local` CURIEs, plus
+  `AcquiriumClient.namespace_manager` exposing the server's bound
+  prefixes as an rdflib `NamespaceManager`.
+- `tests/unit/test_bundled_ontologies.py`,
+  `tests/unit/test_embedding_cache.py`, and tests covering CURIE
+  prefix conversion and namespace transfer on graph insert.
 
 ### Changed
 - The QUDT converter is now built lazily from the in-store QUDT graph
   (`graph_store.named_graph(QUDT_UNIT_IRI)`) instead of re-parsing the
   bundled TTL. User overrides at the canonical QUDT IRI are honored
   automatically.
+- Client URI/CURIE handling now uses rdflib's `NamespaceManager`
+  instead of manual longest-prefix string matching; query results and
+  metadata render identifiers as compact `prefix:local` CURIEs.
+- Prefix bindings declared in inserted Turtle/RDF (`@prefix`) are now
+  propagated into the query dataset, so they survive into the
+  `/namespace/list` endpoint. `OxigraphGraphStore.namespace_manager`
+  now returns the query dataset's manager.
+- Query result assembly is unified in the client `DataObject` and the
+  wide→long reshape uses native Polars expressions instead of nested
+  Python loops.
 - Bumped `pyontoenv` to `0.6.0a2`.
 
 ### Removed
@@ -47,6 +64,8 @@ change in any release.
   all unused after the refactor. (`Manager.__init__` still accepts
   `qudt_converter` and `qudt_graph` for callers who want to inject a
   pre-built converter.)
+- `AcquiriumClient.list_namespaces` and `strip_namespace`, replaced by
+  `namespace_manager` / `compact_uri` / `expand_uri`.
 
 ## [0.3.0] - 2026-05-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,11 @@ build-backend = "hatchling.build"
 # Ship bundled ontology TTL files inside the wheel/sdist so
 # `importlib.resources.files("acquirium._ontologies")` works after
 # `pip install acquirium` — no reliance on a sibling `ontologies/` dir.
+# The `_ontologies` package (and its .ttl data) ships automatically as
+# part of `packages`; do NOT also `force-include` it or every file ends
+# up twice in the wheel ("Duplicate filename in local headers" on upload).
 [tool.hatch.build.targets.wheel]
 packages = ["src/acquirium"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/acquirium/_ontologies" = "acquirium/_ontologies"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acquirium"
-version = "0.3.0"
+version = "0.3.1"
 description = "Acquirium: A data-metadata management platform for water treatment systems"
 readme = "README.md"
 authors = [

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -17,7 +17,7 @@ from acquirium.internals.models import (
 )
 from acquirium.internals.internals_namespaces import *
 from acquirium.Grafana.grafana_dashboard_creator import GrafanaDashboardCreator
-
+from rdflib import Graph, URIRef
 import logging
 logger = logging.getLogger(__name__)
 
@@ -216,57 +216,34 @@ class AcquiriumClient:
         _raise_for_status(response)
         return response.json()
 
-    def list_namespaces(self) -> dict[str, str]:
-        """Return the bound ``prefix -> namespace URI`` map from the server.
+    def namespace_graph(self) -> Graph:
+        """Return the Graph that has the ``prefix -> namespace URI`` map from the server.
 
-        Cached on the client after the first call.
+        Stores (caches) in a rdf Graph object for use by other methods. 
         """
         if self._namespaces_cache is None:
             url = f"{self.base_url}/namespace/list"
             response = requests.get(url)
             _raise_for_status(response)
-            self._namespaces_cache = response.json()
+            self._namespaces_cache = Graph()
+            for prefix, ns_uri in response.json().items():
+                self._namespaces_cache.bind(prefix, ns_uri)
         return self._namespaces_cache
-
-    def strip_namespace(self, item: Any) -> str:
-        """Strip the namespace from a URI, returning only the local name.
-
-        Uses the bound namespaces from ``list_namespaces`` (longest-prefix
-        match). Falls back to splitting on ``#`` or ``/`` when no bound
-        namespace matches; non-URI strings are returned unchanged.
-        """
-        s = str(item)
-        best = ""
-        for ns_uri in self.list_namespaces().values():
-            if s.startswith(ns_uri) and len(ns_uri) > len(best):
-                best = ns_uri
-        if best:
-            return s[len(best):]
-        if "#" in s:
-            return s.rsplit("#", 1)[-1]
-        if "/" in s:
-            return s.rsplit("/", 1)[-1]
-        return s
-
-    def compact_uri(self, item: Any) -> str:
+      
+    def compact_uri(self, item: str|URIRef) -> str:
         """Return ``prefix:local`` for a URI using bound namespaces.
 
         Longest-prefix match against ``list_namespaces``. Falls back to the
         bare local name (``strip_namespace``) when no prefix is bound, and
         passes non-URI strings through unchanged.
         """
-        if not looks_like_uri(item):
-            return str(item)
         s = str(item)
-        best_prefix = ""
-        best_uri = ""
-        for prefix, ns_uri in self.list_namespaces().items():
-            if s.startswith(ns_uri) and len(ns_uri) > len(best_uri):
-                best_prefix = prefix
-                best_uri = ns_uri
-        if best_uri:
-            return f"{best_prefix}:{s[len(best_uri):]}"
-        return self.strip_namespace(s)
+        nm = self.namespace_graph().namespace_manager
+        try:
+            return nm.curie(s, generate=True)
+        except:
+            raise ValueError(f"Cannot compact '{s}': no matching namespace for URI and not a valid URI format")
+
 
     def expand_uri(self, text: Any) -> str:
         """Expand a ``prefix:local`` CURIE to a full URI using bound namespaces.
@@ -276,16 +253,11 @@ class AcquiriumClient:
         the input unchanged if the prefix is not bound.
         """
         s = str(text)
-        if looks_like_uri(s):
-            return s
-        if ":" not in s:
-            return s
-        prefix, _, local = s.partition(":")
-        ns_uri = self.list_namespaces().get(prefix)
-        if ns_uri is None:
-            return s
-        return f"{ns_uri}{local}"
-
+        nm = self.namespace_graph().namespace_manager
+        try:
+            return str(nm.expand_curie(s))
+        except Exception as e:
+            raise ValueError(f"Cannot expand '{s}': no matching namespace for CURIE and not a full URI")
 
     def resolve_text(
         self,

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -18,6 +18,7 @@ from acquirium.internals.models import (
 from acquirium.internals.internals_namespaces import *
 from acquirium.Grafana.grafana_dashboard_creator import GrafanaDashboardCreator
 from rdflib import Graph, URIRef
+from rdflib.namespace import NamespaceManager
 import logging
 logger = logging.getLogger(__name__)
 
@@ -216,7 +217,7 @@ class AcquiriumClient:
         _raise_for_status(response)
         return response.json()
 
-    def namespace_graph(self) -> Graph:
+    def namespace_manager(self) -> NamespaceManager:
         """Return the Graph that has the ``prefix -> namespace URI`` map from the server.
 
         Stores (caches) in a rdf Graph object for use by other methods. 
@@ -228,7 +229,7 @@ class AcquiriumClient:
             self._namespaces_cache = Graph()
             for prefix, ns_uri in response.json().items():
                 self._namespaces_cache.bind(prefix, ns_uri)
-        return self._namespaces_cache
+        return self._namespaces_cache.namespace_manager
       
     def compact_uri(self, item: str|URIRef) -> str:
         """Return ``prefix:local`` for a URI using bound namespaces.
@@ -238,7 +239,7 @@ class AcquiriumClient:
         passes non-URI strings through unchanged.
         """
         s = str(item)
-        nm = self.namespace_graph().namespace_manager
+        nm = self.namespace_manager()
         try:
             return nm.curie(s, generate=True)
         except:
@@ -253,7 +254,7 @@ class AcquiriumClient:
         the input unchanged if the prefix is not bound.
         """
         s = str(text)
-        nm = self.namespace_graph().namespace_manager
+        nm = self.namespace_manager()
         try:
             return str(nm.expand_curie(s))
         except Exception as e:

--- a/src/acquirium/Client/client.py
+++ b/src/acquirium/Client/client.py
@@ -248,6 +248,44 @@ class AcquiriumClient:
             return s.rsplit("/", 1)[-1]
         return s
 
+    def compact_uri(self, item: Any) -> str:
+        """Return ``prefix:local`` for a URI using bound namespaces.
+
+        Longest-prefix match against ``list_namespaces``. Falls back to the
+        bare local name (``strip_namespace``) when no prefix is bound, and
+        passes non-URI strings through unchanged.
+        """
+        if not looks_like_uri(item):
+            return str(item)
+        s = str(item)
+        best_prefix = ""
+        best_uri = ""
+        for prefix, ns_uri in self.list_namespaces().items():
+            if s.startswith(ns_uri) and len(ns_uri) > len(best_uri):
+                best_prefix = prefix
+                best_uri = ns_uri
+        if best_uri:
+            return f"{best_prefix}:{s[len(best_uri):]}"
+        return self.strip_namespace(s)
+
+    def expand_uri(self, text: Any) -> str:
+        """Expand a ``prefix:local`` CURIE to a full URI using bound namespaces.
+
+        Passes already-full URIs (``urn:``, ``http://``, ``https://``)
+        through unchanged. Non-string inputs are cast to ``str``. Returns
+        the input unchanged if the prefix is not bound.
+        """
+        s = str(text)
+        if looks_like_uri(s):
+            return s
+        if ":" not in s:
+            return s
+        prefix, _, local = s.partition(":")
+        ns_uri = self.list_namespaces().get(prefix)
+        if ns_uri is None:
+            return s
+        return f"{ns_uri}{local}"
+
 
     def resolve_text(
         self,

--- a/src/acquirium/Client/data_object.py
+++ b/src/acquirium/Client/data_object.py
@@ -654,7 +654,12 @@ class DataObject:
             pts = points_per_alias.get(alias, set())
             if len(pts) <= 1:
                 return alias
-            return f"{alias}__{self._client.compact_uri(point_uri)}"
+            try:
+                return f"{alias}__{self._client.compact_uri(point_uri)}"
+            except:
+                # we shouldn't come here
+                return f"{alias}__{point_uri}"
+
 
         tall = tall.with_columns(
             pl.struct(["data_alias", "point_uri"])

--- a/src/acquirium/Client/data_object.py
+++ b/src/acquirium/Client/data_object.py
@@ -617,7 +617,13 @@ class DataObject:
     # Flat DataFrame (triggers materialization)
     # ------------------------------------------------------------------
 
-    def dataframe(self, shape: str = "wide") -> pl.DataFrame:
+    def dataframe(
+        self,
+        shape: str = "wide",
+        *,
+        include_ref: bool = False,
+        compact: bool = False,
+    ) -> pl.DataFrame:
         """Return a flat DataFrame.
 
         - ``shape="narrow"``: returns the internal tall frame as-is (every
@@ -627,11 +633,21 @@ class DataObject:
           (first-wins). When an alias resolves to a single point the column
           is just the alias; when it resolves to several points the columns
           are disambiguated as ``f"{alias}__{point_local}"``.
+
+        ``compact=True`` (used by :meth:`Query.dataframe`) renders URIs as
+        CURIEs and identifies points with a ``point_id`` column rather than the
+        raw ``point_uri``/``ref_uri``; auto-aliased data nodes are labelled by
+        their compacted point-local name. In this mode the narrow layout is
+        ``["data_alias", "point_id", "time", "value_numeric", "value_text"]``
+        and ``include_ref=True`` adds the compacted ``ref`` column.
         """
         self._materialize()
 
         if self._tall.is_empty():
             return self._tall
+
+        if compact:
+            return self._compact_dataframe(shape=shape, include_ref=include_ref)
 
         if shape == "narrow":
             return self._tall.sort("time")
@@ -656,7 +672,7 @@ class DataObject:
                 return alias
             try:
                 return f"{alias}__{self._client.compact_uri(point_uri)}"
-            except:
+            except Exception:
                 # we shouldn't come here
                 return f"{alias}__{point_uri}"
 
@@ -671,6 +687,63 @@ class DataObject:
         )
 
         return _pivot_split_values(tall, "_pivot_key")
+
+    def _compact_dataframe(self, *, shape: str, include_ref: bool) -> pl.DataFrame:
+        """Query-compatible layout: CURIE-rendered URIs and a ``point_id`` column.
+
+        Auto-aliased data nodes (alias == ``str(nid)``) are labelled by their
+        compacted point-local name; user aliases that resolve to several points
+        are disambiguated as ``f"{alias}__{point_local}"``.
+        """
+        def _compact(uri: str) -> str:
+            try:
+                return self._client.compact_uri(uri)
+            except Exception:
+                return uri
+
+        # Combine ref_uris sharing the same (data_alias, point_uri, time).
+        tall = self._tall.clone().unique(
+            subset=["data_alias", "point_uri", "time"], keep="first"
+        )
+
+        points_per_alias: dict[str, set[str]] = {}
+        auto_aliases: set[str] = set()
+        for b in self._bindings:
+            points_per_alias.setdefault(b.alias, set()).add(b.point_uri)
+            if b.alias == str(b.nid):
+                auto_aliases.add(b.alias)
+
+        def _label(alias: str, point_uri: str) -> str:
+            if alias in auto_aliases:
+                return _compact(point_uri)
+            if len(points_per_alias.get(alias, set())) > 1:
+                return f"{alias}__{_compact(point_uri)}"
+            return alias
+
+        tall = tall.with_columns(
+            pl.struct(["data_alias", "point_uri"])
+            .map_elements(
+                lambda s: _label(s["data_alias"], s["point_uri"]),
+                return_dtype=pl.Utf8,
+            )
+            .alias("_label")
+        )
+
+        if shape == "narrow":
+            out = tall.with_columns(
+                pl.col("_label").alias("data_alias"),
+                pl.col("point_uri").map_elements(_compact, return_dtype=pl.Utf8).alias("point_id"),
+            )
+            cols = ["data_alias", "point_id", "time", "value_numeric", "value_text"]
+            if include_ref:
+                out = out.with_columns(
+                    pl.col("ref_uri").map_elements(_compact, return_dtype=pl.Utf8).alias("ref")
+                )
+                cols.insert(2, "ref")
+            return out.select(cols).sort("time")
+
+        # wide
+        return _pivot_split_values(tall, "_label")
 
     # ------------------------------------------------------------------
     # Iteration (triggers materialization)

--- a/src/acquirium/Client/data_object.py
+++ b/src/acquirium/Client/data_object.py
@@ -433,6 +433,16 @@ class DataObject:
                 continue
 
             df = df.rename({"ts": "time", "uri": "ref_uri"})
+            if cast_value == "float" and "value" in df.columns:
+                try:
+                    df = df.with_columns(pl.col("value").cast(pl.Float64, strict=True))
+                except Exception:
+                    logger.warning("DataObject: casting value to float failed for ref %s", binding.ref_uri)
+            elif cast_value == "int" and "value" in df.columns:
+                try:
+                    df = df.with_columns(pl.col("value").cast(pl.Int64, strict=True))
+                except Exception:
+                    logger.warning("DataObject: casting value to int failed for ref %s", binding.ref_uri)
             df = df.with_columns(
                 pl.lit(binding.alias).alias("data_alias"),
                 pl.lit(binding.point_uri).alias("point_uri"),
@@ -492,18 +502,6 @@ class DataObject:
             return
 
         tall = pl.concat([_split_value_column(df) for df in frames], how="vertical")
-
-        # Cast value column
-        if cast_value == "float" and "value" in tall.columns:
-            try:
-                tall = tall.with_columns(pl.col("value").cast(pl.Float64, strict=True))
-            except Exception:
-                logger.warning("DataObject: casting value to float failed")
-        elif cast_value == "int" and "value" in tall.columns:
-            try:
-                tall = tall.with_columns(pl.col("value").cast(pl.Int64, strict=True))
-            except Exception:
-                logger.warning("DataObject: casting value to int failed")
 
         # Apply pending conversions (from convert_to() on a lazy DataObject)
         for alias_pat, from_unit, to_unit in self._pending_conversions:
@@ -656,7 +654,7 @@ class DataObject:
             pts = points_per_alias.get(alias, set())
             if len(pts) <= 1:
                 return alias
-            return f"{alias}__{self._client.strip_namespace(point_uri)}"
+            return f"{alias}__{self._client.compact_uri(point_uri)}"
 
         tall = tall.with_columns(
             pl.struct(["data_alias", "point_uri"])
@@ -817,13 +815,24 @@ class DataObject:
         if self._client is None:
             raise ValueError("Cannot convert units without a client connection")
 
+        def _to_uri(identifier: str, *, param: str) -> str:
+            try:
+                return self._client.resolve_unit(identifier)["uri"]
+            except Exception as e:
+                raise ValueError(
+                    f"convert_to: could not resolve {param}={identifier!r} to a QUDT unit URI ({e})"
+                ) from e
+
+        to_unit_uri = _to_uri(to_unit, param="to_unit")
+        from_unit_uri = _to_uri(from_unit, param="from_unit") if from_unit is not None else None
+
         effective = self._resolve_effective_units()
         affected_aliases = [alias] if alias else self.aliases
 
         # Validate and determine from_unit per alias
         conversions: list[tuple[str, str, str]] = []  # (alias, from, to)
         for a in affected_aliases:
-            src = from_unit
+            src = from_unit_uri
             if src is None:
                 src = effective.get(a)
                 if src is None:
@@ -831,7 +840,7 @@ class DataObject:
                         f"No unit annotation found for alias '{a}'. "
                         f"Provide from_unit explicitly."
                     )
-            conversions.append((a, src, to_unit))
+            conversions.append((a, src, to_unit_uri))
 
         # Deduplicate factor requests
         factor_pairs = {(c[1], c[2]) for c in conversions}

--- a/src/acquirium/Client/query.py
+++ b/src/acquirium/Client/query.py
@@ -693,6 +693,7 @@ class Query:
                 .map_elements(
                     lambda x: self._compact_uri_safe(x) if isinstance(x, str) else str(x),
                     return_dtype=pl.String,
+                    skip_nulls=False,
                 )
                 .alias(c)
                 for c in cols_w_alias

--- a/src/acquirium/Client/query.py
+++ b/src/acquirium/Client/query.py
@@ -181,9 +181,19 @@ class Query:
             return None
         if isinstance(uri, URIRef):
             return str(uri)
-        if isinstance(uri, str) and self._is_uri(uri):
-            return uri
-        raise ValueError(f"{param} must be a URI (urn:..., http://..., or https://...)")
+        if isinstance(uri, str):
+            if self._is_uri(uri):
+                return uri
+            # Try CURIE expansion: "prefix:local" -> "<namespace_uri>local"
+            if ":" in uri:
+                prefix, _, local = uri.partition(":")
+                ns_uri = self.client.list_namespaces().get(prefix)
+                if ns_uri is not None:
+                    return f"{ns_uri}{local}"
+        raise ValueError(
+            f"{param} must be a URI (urn:..., http://..., https://...) "
+            f"or a CURIE 'prefix:local' with a bound prefix"
+        )
 
     def _find_all_nodes(self, id_val=None) -> set[URIRef]:
         '''
@@ -714,7 +724,7 @@ class Query:
             points_per_nid.setdefault(nid, set()).add(point_uri)
 
         def _resolve_label(nid: int, point_uri: str) -> str:
-            point_local = self.client.strip_namespace(point_uri)
+            point_local = self.client.compact_uri(point_uri)
             alias = self.query_graph.aliases_reverse.get(nid)
             # An auto-alias like "0" (str of node id) is treated as no alias.
             if alias is None or alias == str(nid):
@@ -739,6 +749,16 @@ class Query:
                 continue
 
             df = df.rename({"value": "value", "ts": "time","uri": "ref"})
+            if cast_value == "float" and "value" in df.columns:
+                try:
+                    df = df.with_columns(pl.col("value").cast(pl.Float64, strict=True))
+                except Exception:
+                    logging.warning("casting to float failed for ref %s", ref_uri)
+            elif cast_value == "int" and "value" in df.columns:
+                try:
+                    df = df.with_columns(pl.col("value").cast(pl.Int64, strict=True))
+                except Exception:
+                    logging.warning("casting to int failed for ref %s", ref_uri)
             df = _split_value_column(df)
             df = df.with_columns(
                 pl.lit(point_uri).alias("point_id"),
@@ -750,22 +770,8 @@ class Query:
             return pl.DataFrame({"data_alias": [], "point_id": [], "time": [], "value_numeric": [], "value_text": []})
 
         tall = pl.concat(frames, how="vertical")
-
-        # optional casting
-        if cast_value == "float" and "value" in tall.columns:
-            try:
-                tall = tall.with_columns(pl.col("value").cast(pl.Float64, strict=True))
-            except Exception:
-                logging.warning("casting to float failed")
-                pass
-        elif cast_value == "int" and "value" in tall.columns:
-            try:
-                tall = tall.with_columns(pl.col("value").cast(pl.Int64, strict=True))
-            except Exception:
-                logging.warning("casting to int failed")
-                pass
-        tall = tall.with_columns(pl.col("point_id").map_elements(lambda x: self.client.strip_namespace(x),return_dtype=pl.Utf8).alias("point_id"))
-        tall = tall.with_columns(pl.col("ref").map_elements(lambda x: self.client.strip_namespace(x),return_dtype=pl.Utf8).alias("ref"))
+        tall = tall.with_columns(pl.col("point_id").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("point_id"))
+        tall = tall.with_columns(pl.col("ref").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("ref"))
 
         # Combine multiple ref_uris that share the same (data_alias, point_id,
         # time) — first row wins.  This implements the "combine refs per point"
@@ -787,7 +793,7 @@ class Query:
         if col_name == "time":
             return col_name
         if isinstance(col_name, str):
-            return self.client.strip_namespace(col_name)
+            return self.client.compact_uri(col_name)
         if isinstance(col_name, set):
             return list(col_name)[1]
         return str(col_name)
@@ -820,7 +826,7 @@ class Query:
             cols_kept = [cols[i] for i in keep_idx]
             rows_kept = [[r[i] for i in keep_idx] for r in rows]
             cols_w_alias = [self._col_name_to_alias(c) for c in cols_kept]
-            rows_clean = [[self.client.strip_namespace(i) for i in r] for r in rows_kept]
+            rows_clean = [[self.client.compact_uri(i) for i in r] for r in rows_kept]
             pl_table = pl.DataFrame(rows_clean, schema=cols_w_alias, orient="row")
             self.cache[cache_key] = pl_table
         return self.cache[cache_key]
@@ -1460,7 +1466,7 @@ class Query:
             table.add_column(self._col_name_to_alias(col))
 
         for row in rows[:n]:
-            table.add_row(*[self.client.strip_namespace(x) for x in row])
+            table.add_row(*[self.client.compact_uri(x) for x in row])
 
         console.print(table)
 

--- a/src/acquirium/Client/query.py
+++ b/src/acquirium/Client/query.py
@@ -691,7 +691,7 @@ class Query:
             pl_table = pl_table.with_columns([
                 pl.col(c)
                 .map_elements(
-                    lambda x: self._compact_uri_safe(x) if isinstance(x, str) else x,
+                    lambda x: self._compact_uri_safe(x) if isinstance(x, str) else str(x),
                     return_dtype=pl.String,
                 )
                 .alias(c)

--- a/src/acquirium/Client/query.py
+++ b/src/acquirium/Client/query.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from acquirium.TextMatch.decorators import flex_query_rdf_inputs, FlexSpec
 from acquirium.Client.query_graph import QueryGraph, QueryNode, QueryEdge, DataNodeInfo
 from acquirium.Client.client import AcquiriumClient
-from acquirium.Client.data_object import _pivot_split_values, _split_value_column
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
@@ -636,176 +635,28 @@ class Query:
         value_mode: str = "default",
         include_ref: bool = False,
     ) -> pl.DataFrame:
-        """
-        Fetch time series for all bound data nodes in this query result.
+        """Convenience wrapper around :meth:`data`.
 
-        Column naming uses the data node alias when defined; when one alias
-        resolves to multiple distinct point_uris, columns are disambiguated as
-        ``f"{alias}__{point_local}"``. Data from multiple ref_uris that share
-        the same (alias, point_uri) are combined (first-wins).
+        Equivalent to ``self.data(...).dataframe(shape=..., include_ref=...,
+        compact=True)``: it builds a :class:`DataObject` with the given fetch
+        parameters and renders it in the compact, CURIE-rendered layout.
 
         Returns:
         - wide: columns ``["time", <alias_or_point_local_1>, ...]``
         - narrow: columns ``["data_alias", "point_id", "time", "value_numeric",
-          "value_text"]``. Pass ``include_ref=True`` to also include the raw
-          ``ref`` column (ref_uri local name) for per-ref-uri use cases.
+          "value_text"]``. Pass ``include_ref=True`` to also include the
+          compacted ``ref`` column for per-ref-uri use cases.
         """
-        if not getattr(self.query_graph, "data_nodes", None):
-            return pl.DataFrame({"time": [], "value": [], "point_id": [], "data_alias": []})
+        return self.data(
+            start=start,
+            end=end,
+            limit=limit,
+            order=order,
+            use_union=use_union,
+            cast_value=cast_value,
+            value_mode=value_mode,
+        ).dataframe(shape=shape, include_ref=include_ref, compact=True)
 
-        res = self.execute(use_union=use_union)
-        cols: list[str] = res.get("columns", []) #v0, v1, ext1, ...
-        rows: list[list[Any]] = res.get("rows", [])
-
-        # map "v<ID>" column -> ID
-        col_to_id: dict[int, int] = {}
-        ext_ref_col_to_id: dict[int, int] = {}
-        for i, c in enumerate(cols):
-            if isinstance(c, str) and c.startswith("v"):
-                try:
-                    nid = int(c[1:])
-                    col_to_id[i] = nid
-                except ValueError:
-                    pass
-            elif isinstance(c, str) and c.startswith("ext"):
-                try:
-                    nid = int(c[3:])
-                    ext_ref_col_to_id[i] = nid
-                except ValueError:
-                    pass
-        nid_to_ext_ref_col: dict[int, int] = {v: k for k, v in ext_ref_col_to_id.items()}
-
-        data_node_ids = set(self.query_graph.data_nodes.keys())
-        data_col_indices = [i for i, nid in col_to_id.items() if nid in data_node_ids]
-        ref_col_indices = [i for i, nid in ext_ref_col_to_id.items() if nid in data_node_ids]
-        if not data_col_indices or not ref_col_indices:
-            return pl.DataFrame({"data_alias": [], "point_id": [], "time": [], "value": []})
-
-        # gather unique point URIs bound to data nodes
-        point_ref_uris: list[tuple[int, str, str]] = []
-        seen = set()
-        for r in rows:
-            for i in data_col_indices:
-                nid = col_to_id[i]
-                uri = r[i]
-                if uri is None:
-                    continue
-                uri_s = str(uri)
-                if nid in nid_to_ext_ref_col:
-                    ref_col_idx = nid_to_ext_ref_col[nid]
-                    if ref_col_idx >= len(r):
-                        continue
-                    ref_uri = r[ref_col_idx]
-                    if ref_uri is None:
-                        continue
-                    ref_uri_s = str(ref_uri)
-                    key = (nid, uri_s, ref_uri_s)
-                    if key not in seen:
-                        seen.add(key)
-                        point_ref_uris.append((nid, uri_s, ref_uri_s))
-
-        if not point_ref_uris:
-            return pl.DataFrame({"data_alias": [], "point_id": [], "time": [], "value": []})
-
-        # Resolve per-data-node alias and decide a pivot/column key for each
-        # (nid, point_uri) binding.  Rules:
-        #   - column name = alias when the data node has one and resolves to
-        #     a single point_uri.
-        #   - when an alias resolves to several points, append the cleaned
-        #     point local name: ``f"{alias}__{point_local}"``.
-        #   - when the data node has no user alias (auto str(nid)), fall back
-        #     to the cleaned point local name.
-        points_per_nid: dict[int, set[str]] = {}
-        for nid, point_uri, _ in point_ref_uris:
-            points_per_nid.setdefault(nid, set()).add(point_uri)
-
-        def _resolve_label(nid: int, point_uri: str) -> str:
-            try:
-                point_local = self.client.compact_uri(point_uri)
-            except:
-                point_local = point_uri
-            alias = self.query_graph.aliases_reverse.get(nid)
-            # An auto-alias like "0" (str of node id) is treated as no alias.
-            if alias is None or alias == str(nid):
-                return point_local
-            if len(points_per_nid.get(nid, set())) > 1:
-                return f"{alias}__{point_local}"
-            return alias
-
-        # fetch time series for each point URI and build tall frame
-        frames: list[pl.DataFrame] = []
-        for nid, point_uri, ref_uri in point_ref_uris:
-
-            df = self.client.timeseries_df(
-                ref_uri,
-                start=start,
-                end=end,
-                limit=limit,
-                order=order,
-                value_mode=value_mode,
-            )
-            if df.is_empty():
-                continue
-
-            df = df.rename({"value": "value", "ts": "time","uri": "ref"})
-            if cast_value == "float" and "value" in df.columns:
-                try:
-                    df = df.with_columns(pl.col("value").cast(pl.Float64, strict=True))
-                except Exception:
-                    logging.warning("casting to float failed for ref %s", ref_uri)
-            elif cast_value == "int" and "value" in df.columns:
-                try:
-                    df = df.with_columns(pl.col("value").cast(pl.Int64, strict=True))
-                except Exception:
-                    logging.warning("casting to int failed for ref %s", ref_uri)
-            df = _split_value_column(df)
-            df = df.with_columns(
-                pl.lit(point_uri).alias("point_id"),
-                pl.lit(_resolve_label(nid, point_uri)).alias("data_alias"),
-            )
-            frames.append(df)
-
-        if not frames:
-            return pl.DataFrame({"data_alias": [], "point_id": [], "time": [], "value_numeric": [], "value_text": []})
-
-        tall = pl.concat(frames, how="vertical")
-        try:
-            tall = tall.with_columns(pl.col("point_id").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("point_id"))
-        except:
-            pass
-        try:
-            tall = tall.with_columns(pl.col("ref").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("ref"))
-        except:
-            pass
-
-        # Combine multiple ref_uris that share the same (data_alias, point_id,
-        # time) — first row wins.  This implements the "combine refs per point"
-        # contract for the default view.
-        tall = tall.unique(subset=["data_alias", "point_id", "time"], keep="first")
-
-        if shape == "narrow":
-            base_cols = ["data_alias", "point_id", "time", "value_numeric", "value_text"]
-            if include_ref:
-                base_cols.insert(2, "ref")
-            return tall.select(base_cols).sort("time")
-
-        # wide
-        wide = _pivot_split_values(tall.rename({"data_alias": "_pivot_key"}), "_pivot_key")
-        wide.columns = [self._clean_column_name(c) for c in wide.columns]
-        return wide.sort("time")
-
-    def _clean_column_name(self, col_name: str) -> str:
-        if col_name == "time":
-            return col_name
-        if isinstance(col_name, str):
-            try:
-                return self.client.compact_uri(col_name)
-            except:
-                pass
-        if isinstance(col_name, set):
-            return list(col_name)[1]
-        return str(col_name)
-    
     def metadata(self, *, include_internals: bool = False) -> pl.DataFrame:
         """
         Execute the SPARQL query to get the query graph results.

--- a/src/acquirium/Client/query.py
+++ b/src/acquirium/Client/query.py
@@ -179,17 +179,13 @@ class Query:
     def _normalize_instance_uri(self, uri: str | URIRef | None, *, param: str = "uri") -> str | None:
         if uri is None:
             return None
-        if isinstance(uri, URIRef):
+        if isinstance(uri, URIRef) or (isinstance(uri, str) and self._is_uri(uri)):
             return str(uri)
         if isinstance(uri, str):
-            if self._is_uri(uri):
-                return uri
-            # Try CURIE expansion: "prefix:local" -> "<namespace_uri>local"
-            if ":" in uri:
-                prefix, _, local = uri.partition(":")
-                ns_uri = self.client.list_namespaces().get(prefix)
-                if ns_uri is not None:
-                    return f"{ns_uri}{local}"
+            try:
+                return self.client.expand_uri(uri)  # for side-effect of validating/normalizing the URI or CURIE
+            except Exception as e:
+                raise ValueError(f"Invalid URI or CURIE '{uri}' for parameter '{param}': {e}")
         raise ValueError(
             f"{param} must be a URI (urn:..., http://..., https://...) "
             f"or a CURIE 'prefix:local' with a bound prefix"
@@ -724,7 +720,10 @@ class Query:
             points_per_nid.setdefault(nid, set()).add(point_uri)
 
         def _resolve_label(nid: int, point_uri: str) -> str:
-            point_local = self.client.compact_uri(point_uri)
+            try:
+                point_local = self.client.compact_uri(point_uri)
+            except:
+                point_local = point_uri
             alias = self.query_graph.aliases_reverse.get(nid)
             # An auto-alias like "0" (str of node id) is treated as no alias.
             if alias is None or alias == str(nid):
@@ -770,8 +769,14 @@ class Query:
             return pl.DataFrame({"data_alias": [], "point_id": [], "time": [], "value_numeric": [], "value_text": []})
 
         tall = pl.concat(frames, how="vertical")
-        tall = tall.with_columns(pl.col("point_id").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("point_id"))
-        tall = tall.with_columns(pl.col("ref").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("ref"))
+        try:
+            tall = tall.with_columns(pl.col("point_id").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("point_id"))
+        except:
+            pass
+        try:
+            tall = tall.with_columns(pl.col("ref").map_elements(lambda x: self.client.compact_uri(x),return_dtype=pl.Utf8).alias("ref"))
+        except:
+            pass
 
         # Combine multiple ref_uris that share the same (data_alias, point_id,
         # time) — first row wins.  This implements the "combine refs per point"
@@ -793,7 +798,10 @@ class Query:
         if col_name == "time":
             return col_name
         if isinstance(col_name, str):
-            return self.client.compact_uri(col_name)
+            try:
+                return self.client.compact_uri(col_name)
+            except:
+                pass
         if isinstance(col_name, set):
             return list(col_name)[1]
         return str(col_name)
@@ -826,7 +834,20 @@ class Query:
             cols_kept = [cols[i] for i in keep_idx]
             rows_kept = [[r[i] for i in keep_idx] for r in rows]
             cols_w_alias = [self._col_name_to_alias(c) for c in cols_kept]
-            rows_clean = [[self.client.compact_uri(i) for i in r] for r in rows_kept]
+            rows_clean = []
+            for r in rows_kept:
+                new_row = []
+                for cell in r:
+                    if isinstance(cell, str):
+                        try:
+                            new_cell = self.client.compact_uri(cell)
+                        except:
+                            new_cell = cell
+                    else:
+                        new_cell = cell
+                    new_row.append(new_cell)
+                rows_clean.append(new_row)
+
             pl_table = pl.DataFrame(rows_clean, schema=cols_w_alias, orient="row")
             self.cache[cache_key] = pl_table
         return self.cache[cache_key]
@@ -1466,7 +1487,13 @@ class Query:
             table.add_column(self._col_name_to_alias(col))
 
         for row in rows[:n]:
-            table.add_row(*[self.client.compact_uri(x) for x in row])
+            add_row = []
+            for x in row:
+                try:
+                    add_row.append(self.client.compact_uri(x))
+                except:
+                    add_row.append(x)
+            table.add_row(*add_row)
 
         console.print(table)
 

--- a/src/acquirium/Client/query.py
+++ b/src/acquirium/Client/query.py
@@ -685,21 +685,18 @@ class Query:
             cols_kept = [cols[i] for i in keep_idx]
             rows_kept = [[r[i] for i in keep_idx] for r in rows]
             cols_w_alias = [self._col_name_to_alias(c) for c in cols_kept]
-            rows_clean = []
-            for r in rows_kept:
-                new_row = []
-                for cell in r:
-                    if isinstance(cell, str):
-                        try:
-                            new_cell = self.client.compact_uri(cell)
-                        except:
-                            new_cell = cell
-                    else:
-                        new_cell = cell
-                    new_row.append(new_cell)
-                rows_clean.append(new_row)
-
-            pl_table = pl.DataFrame(rows_clean, schema=cols_w_alias, orient="row")
+            
+            pl_table = pl.DataFrame(rows_kept, schema=cols_w_alias, orient="row")
+            
+            pl_table = pl_table.with_columns([
+                pl.col(c)
+                .map_elements(
+                    lambda x: self._compact_uri_safe(x) if isinstance(x, str) else x,
+                    return_dtype=pl.String,
+                )
+                .alias(c)
+                for c in cols_w_alias
+            ])
             self.cache[cache_key] = pl_table
         return self.cache[cache_key]
 
@@ -1338,16 +1335,16 @@ class Query:
             table.add_column(self._col_name_to_alias(col))
 
         for row in rows[:n]:
-            add_row = []
-            for x in row:
-                try:
-                    add_row.append(self.client.compact_uri(x))
-                except:
-                    add_row.append(x)
-            table.add_row(*add_row)
-
+            table.add_row(*[self._compact_uri_safe(str(cell)) for cell in row])
+            
         console.print(table)
 
+    def _compact_uri_safe(self, uri: str) -> str:
+        try:
+            return self.client.compact_uri(uri)
+        except:
+            return str(uri)
+    
     def _pretty_print_graph(self) -> None:
         print("QUERY GRAPH")
 

--- a/src/acquirium/Storage/graph_store.py
+++ b/src/acquirium/Storage/graph_store.py
@@ -394,6 +394,20 @@ class OxigraphGraphStore:
             main.remove((None, None, None))
         for triple in incoming:
             main.add(triple)
+        # Propagate prefix bindings declared in the incoming Turtle/RDF
+        # (rdflib's parser populates incoming.namespace_manager from
+        # `@prefix` directives) so they survive into the stores that back
+        # the public /namespace/list endpoint.
+        for prefix, ns_uri in incoming.namespaces():
+            try:
+                main.bind(prefix, ns_uri, override=False)
+                self.query_dataset.namespace_manager.bind(
+                    prefix, ns_uri, override=False
+                )
+            except Exception:
+                _logger.debug(
+                    "namespace bind failed for %s=%s", prefix, ns_uri, exc_info=True
+                )
         return main
 
     def _finalize_source_write(self, *, affects_closure: bool) -> None:
@@ -492,7 +506,7 @@ class OxigraphGraphStore:
         }
 
     def namespace_manager(self) -> NamespaceManager :
-        return self.source_dataset.namespace_manager
+        return self.query_dataset.namespace_manager
     
     # -------------------- helpers --------------------
     def _materialize_point(self, subject: URIRef) -> Point:

--- a/tests/test_query_data.py
+++ b/tests/test_query_data.py
@@ -1,4 +1,5 @@
 import pytest
+import polars as pl
 from acquirium import Acquirium
 from acquirium.internals.internals_namespaces import *
 from acquirium.internals.models import compute_ref_uri
@@ -68,37 +69,154 @@ def test_data_filters(acquirium_client_csv):
     filt_medium_1 = query.filter_by_medium(ACQUIRIUM_NS.Medium4)
     meta_1 = filt_medium_1.metadata()
     assert len(meta_1) == 2
-    assert "point_9" in meta_1["0"].to_list()
+    assert "ex1:point_9" in meta_1["0"].to_list()
 
     filt_medium_2 = query.filter_by_medium(ACQUIRIUM_NS.Medium1)
     meta_2 = filt_medium_2.metadata()
     assert len(meta_2) == 2
-    assert "point_2" in meta_2["0"].to_list()
+    assert "ex1:point_2" in meta_2["0"].to_list()
 
     filt_substance_1 = query.filter_by_substance(ACQUIRIUM_NS.Substance2)
     meta_3 = filt_substance_1.metadata()
     assert len(meta_3) == 3
-    assert "point_3" in meta_3["0"].to_list()
+    assert "ex1:point_3" in meta_3["0"].to_list()
 
     filt_unit_1 = query.filter_by_unit(ACQUIRIUM_NS.Unit0)
     meta_4 = filt_unit_1.metadata()
     assert len(meta_4) == 3
-    assert "point_3" in meta_4["0"].to_list()
+    assert "ex1:point_3" in meta_4["0"].to_list()
 
     filt_quantity_kind_1 = query.filter_by_quantity_kind(ACQUIRIUM_NS.QuantityKind2)
     meta_5 = filt_quantity_kind_1.metadata()
     assert len(meta_5) == 3
-    assert "point_8" in meta_5["0"].to_list()
+    assert "ex1:point_8" in meta_5["0"].to_list()
 
     filt_enumeration_kind_1 = query.filter_by_enumeration_kind(ACQUIRIUM_NS.EnumerationKind1)
     meta_6 = filt_enumeration_kind_1.metadata()
     assert len(meta_6) == 2
-    assert "point_10" in meta_6["0"].to_list()
+    assert "ex1:point_10" in meta_6["0"].to_list()
 
     filt_random = query.filter_data_nodes(predicate=HAS_EXTERNAL_REFERENCE, value=str(compute_ref_uri(_CSV_SOURCE_ID, "point_10")))
     meta_7 = filt_random.metadata()
     assert len(meta_7) == 1
-    assert "point_10" in meta_7["0"].to_list()
+    assert "ex1:point_10" in meta_7["0"].to_list()
+
+
+##### Namespace transfer + CURIE helper tests #####
+
+def test_namespaces_transferred_on_insert(acquirium_client_csv):
+    """insert_graph propagates @prefix bindings into /namespace/list."""
+    acq = acquirium_client_csv
+    ns = acq.list_namespaces()
+
+    # Prefixes declared in tests/test_model_csv.ttl must reach the query store.
+    assert ns.get("acq") == "urn:acquirium#"
+    assert "qudt" in ns
+    assert "s223" in ns
+    # ex: <urn:ex/> is bound (possibly under a de-duplicated prefix, e.g. ex1).
+    assert any(uri == "urn:ex/" for uri in ns.values())
+
+
+def test_compact_uri_roundtrip(acquirium_client_csv):
+    """compact_uri returns prefix:local and round-trips through expand_uri."""
+    acq = acquirium_client_csv
+
+    compact = acq.compact_uri("urn:ex/point_1")
+    assert compact.endswith(":point_1")
+    assert ":" in compact and compact != "point_1"  # keeps prefix, unlike strip_namespace
+    assert acq.expand_uri(compact) == "urn:ex/point_1"
+
+    # acq:* (urn:acquirium#) also compacts to a CURIE that round-trips back.
+    compact_med = acq.compact_uri(str(ACQUIRIUM_NS.Medium4))
+    assert compact_med.endswith(":Medium4")
+    assert acq.expand_uri(compact_med) == str(ACQUIRIUM_NS.Medium4)
+
+
+def test_compact_uri_passthrough_and_fallback(acquirium_client_csv):
+    """Non-URIs pass through; unbound namespaces fall back to the local name."""
+    acq = acquirium_client_csv
+
+    assert acq.compact_uri("just text") == "just text"        # not a URI
+    assert acq.compact_uri(42) == "42"                         # non-string cast
+    assert acq.compact_uri("urn:unbound/thing") == "thing"    # no bound prefix -> bare local
+
+
+def test_expand_uri_passthrough(acquirium_client_csv):
+    """expand_uri leaves full URIs / colon-free / unbound-prefix inputs unchanged."""
+    acq = acquirium_client_csv
+
+    assert acq.expand_uri("urn:ex/point_1") == "urn:ex/point_1"          # already a URI
+    assert acq.expand_uri("http://example.com/x") == "http://example.com/x"
+    assert acq.expand_uri("point_1") == "point_1"                        # no colon
+    assert acq.expand_uri("nope:thing") == "nope:thing"                  # prefix not bound
+
+
+def test_metadata_renders_compact_curie(acquirium_client_csv):
+    """metadata() renders point ids as CURIEs (prefix:local), not bare local names."""
+    acq = acquirium_client_csv
+    meta = acq.find_all_data().metadata()
+
+    ids = meta["0"].to_list()
+    assert all(":" in pid for pid in ids)
+    assert "ex1:point_1" in ids
+
+
+def test_normalize_instance_uri_expands_curie(acquirium_client_csv):
+    """find_entity(uri=...) accepts CURIEs via bound-prefix expansion."""
+    acq = acquirium_client_csv
+    query = acq.find_all_data()
+
+    # CURIE expands using bound prefixes.
+    assert query._normalize_instance_uri("acq:Medium4") == str(ACQUIRIUM_NS.Medium4)
+    assert query._normalize_instance_uri("ex1:point_1") == "urn:ex/point_1"
+
+    # Already-full URIs and URIRefs pass through unchanged.
+    assert query._normalize_instance_uri("urn:ex/point_1") == "urn:ex/point_1"
+    assert query._normalize_instance_uri(ACQUIRIUM_NS.Medium4) == str(ACQUIRIUM_NS.Medium4)
+    assert query._normalize_instance_uri(None) is None
+
+    # Neither a URI nor a bound CURIE -> error.
+    with pytest.raises(ValueError):
+        query._normalize_instance_uri("notaprefix:thing")
+
+
+##### Per-frame value casting tests #####
+
+def test_dataframe_cast_float_is_per_frame(acquirium_client_csv):
+    """cast_value='float' casts each point's frame independently.
+
+    Points 1-8 are numeric and points 9-10 are text. The cast now runs per
+    point frame before the value column is split, so the numeric points land
+    in ``value_numeric`` while the un-castable text points fall back to
+    ``value_text`` instead of one bad frame derailing the whole cast.
+    """
+    acq = acquirium_client_csv
+    df = acq.find_all_data().dataframe(shape="narrow", cast_value="float", limit=5)
+
+    numeric = df.filter(pl.col("point_id") == "ex1:point_1")
+    assert len(numeric) > 0
+    # numeric point populated value_numeric (cast succeeded) and not value_text
+    assert numeric["value_numeric"].null_count() < len(numeric)
+    assert numeric["value_text"].null_count() == len(numeric)
+
+    text = df.filter(pl.col("point_id") == "ex1:point_9")
+    assert len(text) > 0
+    # un-castable text point gracefully stayed in value_text
+    assert text["value_numeric"].null_count() == len(text)
+    assert text["value_text"].null_count() < len(text)
+
+
+def test_dataframe_cast_int_per_frame_does_not_raise(acquirium_client_csv):
+    """cast_value='int' on mixed numeric/text data returns data for both kinds.
+
+    A frame whose values cannot be cast to int is skipped (logged), not fatal.
+    """
+    acq = acquirium_client_csv
+    df = acq.find_all_data().dataframe(shape="narrow", cast_value="int", limit=5)
+
+    point_ids = set(df["point_id"].to_list())
+    assert "ex1:point_1" in point_ids   # numeric point present
+    assert "ex1:point_9" in point_ids   # text point still present, not dropped
 
 
 ##### Find data tests #####

--- a/tests/test_query_data.py
+++ b/tests/test_query_data.py
@@ -104,13 +104,13 @@ def test_data_filters(acquirium_client_csv):
 
 ##### Namespace transfer + CURIE helper tests #####
 # These exercise the rdflib-backed namespace helpers on the client
-# (acq.client.compact_uri / expand_uri / namespace_graph). Prefix names are
+# (acq.client.compact_uri / expand_uri / namespace_manager). Prefix names are
 # environment-dependent (rdflib de-duplicates colliding prefixes), so the tests
 # assert round-trip behaviour and namespace URIs rather than fixed prefixes.
 
-def _bound_namespace_uris(acq):
+def _bound_namespace_uris(acq: Acquirium) -> set[str]:
     """Set of namespace URIs currently bound on the client."""
-    return {str(uri) for _, uri in acq.client.namespace_graph().namespaces()}
+    return {str(uri) for _, uri in acq.client.namespace_manager().namespaces()}
 
 
 def test_namespaces_transferred_on_insert(acquirium_client_csv):

--- a/tests/test_query_data.py
+++ b/tests/test_query_data.py
@@ -103,77 +103,83 @@ def test_data_filters(acquirium_client_csv):
 
 
 ##### Namespace transfer + CURIE helper tests #####
+# These exercise the rdflib-backed namespace helpers on the client
+# (acq.client.compact_uri / expand_uri / namespace_graph). Prefix names are
+# environment-dependent (rdflib de-duplicates colliding prefixes), so the tests
+# assert round-trip behaviour and namespace URIs rather than fixed prefixes.
+
+def _bound_namespace_uris(acq):
+    """Set of namespace URIs currently bound on the client."""
+    return {str(uri) for _, uri in acq.client.namespace_graph().namespaces()}
+
 
 def test_namespaces_transferred_on_insert(acquirium_client_csv):
-    """insert_graph propagates @prefix bindings into /namespace/list."""
+    """insert_graph propagates @prefix bindings from the TTL into /namespace/list."""
     acq = acquirium_client_csv
-    ns = acq.list_namespaces()
+    bound = _bound_namespace_uris(acq)
 
-    # Prefixes declared in tests/test_model_csv.ttl must reach the query store.
-    assert ns.get("acq") == "urn:acquirium#"
-    assert "qudt" in ns
-    assert "s223" in ns
-    # ex: <urn:ex/> is bound (possibly under a de-duplicated prefix, e.g. ex1).
-    assert any(uri == "urn:ex/" for uri in ns.values())
+    # Namespaces declared in tests/test_model_csv.ttl must reach the query store.
+    assert "urn:acquirium#" in bound
+    assert "urn:ex/" in bound
+    assert "http://qudt.org/schema/qudt/" in bound
+    assert "http://data.ashrae.org/standard223#" in bound
 
 
 def test_compact_uri_roundtrip(acquirium_client_csv):
-    """compact_uri returns prefix:local and round-trips through expand_uri."""
-    acq = acquirium_client_csv
+    """compact_uri returns prefix:local for a URI and round-trips through expand_uri."""
+    c = acquirium_client_csv.client
 
-    compact = acq.compact_uri("urn:ex/point_1")
-    assert compact.endswith(":point_1")
-    assert ":" in compact and compact != "point_1"  # keeps prefix, unlike strip_namespace
-    assert acq.expand_uri(compact) == "urn:ex/point_1"
+    compact = c.compact_uri("urn:ex/point_1")
+    assert ":" in compact and compact.endswith(":point_1")
+    assert c.expand_uri(compact) == "urn:ex/point_1"
 
-    # acq:* (urn:acquirium#) also compacts to a CURIE that round-trips back.
-    compact_med = acq.compact_uri(str(ACQUIRIUM_NS.Medium4))
+    # urn:acquirium# round-trips too (the exact prefix is environment-dependent).
+    med = str(ACQUIRIUM_NS.Medium4)
+    compact_med = c.compact_uri(med)
     assert compact_med.endswith(":Medium4")
-    assert acq.expand_uri(compact_med) == str(ACQUIRIUM_NS.Medium4)
+    assert c.expand_uri(compact_med) == med
 
 
-def test_compact_uri_passthrough_and_fallback(acquirium_client_csv):
-    """Non-URIs pass through; unbound namespaces fall back to the local name."""
-    acq = acquirium_client_csv
+def test_compact_uri_rejects_non_uri(acquirium_client_csv):
+    """compact_uri raises on strings that are not splittable URIs."""
+    c = acquirium_client_csv.client
+    with pytest.raises(ValueError):
+        c.compact_uri("just text")
+    with pytest.raises(ValueError):
+        c.compact_uri("point_9")
 
-    assert acq.compact_uri("just text") == "just text"        # not a URI
-    assert acq.compact_uri(42) == "42"                         # non-string cast
-    assert acq.compact_uri("urn:unbound/thing") == "thing"    # no bound prefix -> bare local
 
-
-def test_expand_uri_passthrough(acquirium_client_csv):
-    """expand_uri leaves full URIs / colon-free / unbound-prefix inputs unchanged."""
-    acq = acquirium_client_csv
-
-    assert acq.expand_uri("urn:ex/point_1") == "urn:ex/point_1"          # already a URI
-    assert acq.expand_uri("http://example.com/x") == "http://example.com/x"
-    assert acq.expand_uri("point_1") == "point_1"                        # no colon
-    assert acq.expand_uri("nope:thing") == "nope:thing"                  # prefix not bound
+def test_expand_uri_requires_bound_curie(acquirium_client_csv):
+    """expand_uri only accepts a CURIE whose prefix is bound; full URIs/unbound raise."""
+    c = acquirium_client_csv.client
+    with pytest.raises(ValueError):
+        c.expand_uri("urn:ex/point_1")   # a full URI is not a CURIE
+    with pytest.raises(ValueError):
+        c.expand_uri("nope:thing")       # prefix not bound
 
 
 def test_metadata_renders_compact_curie(acquirium_client_csv):
     """metadata() renders point ids as CURIEs (prefix:local), not bare local names."""
     acq = acquirium_client_csv
-    meta = acq.find_all_data().metadata()
+    ids = acq.find_all_data().metadata()["0"].to_list()
 
-    ids = meta["0"].to_list()
     assert all(":" in pid for pid in ids)
-    assert "ex1:point_1" in ids
+    assert any(pid.endswith(":point_1") for pid in ids)
 
 
-def test_normalize_instance_uri_expands_curie(acquirium_client_csv):
-    """find_entity(uri=...) accepts CURIEs via bound-prefix expansion."""
+def test_normalize_instance_uri(acquirium_client_csv):
+    """find_entity(uri=...) accepts full URIs and bound CURIEs, rejects everything else."""
     acq = acquirium_client_csv
     query = acq.find_all_data()
 
-    # CURIE expands using bound prefixes.
-    assert query._normalize_instance_uri("acq:Medium4") == str(ACQUIRIUM_NS.Medium4)
-    assert query._normalize_instance_uri("ex1:point_1") == "urn:ex/point_1"
-
-    # Already-full URIs and URIRefs pass through unchanged.
+    # Full URI string and URIRef pass through unchanged; None stays None.
     assert query._normalize_instance_uri("urn:ex/point_1") == "urn:ex/point_1"
     assert query._normalize_instance_uri(ACQUIRIUM_NS.Medium4) == str(ACQUIRIUM_NS.Medium4)
     assert query._normalize_instance_uri(None) is None
+
+    # A CURIE with a bound prefix expands back to its full URI.
+    point_curie = acq.client.compact_uri("urn:ex/point_1")
+    assert query._normalize_instance_uri(point_curie) == "urn:ex/point_1"
 
     # Neither a URI nor a bound CURIE -> error.
     with pytest.raises(ValueError):
@@ -193,13 +199,18 @@ def test_dataframe_cast_float_is_per_frame(acquirium_client_csv):
     acq = acquirium_client_csv
     df = acq.find_all_data().dataframe(shape="narrow", cast_value="float", limit=5)
 
-    numeric = df.filter(pl.col("point_id") == "ex1:point_1")
+    # point ids render as CURIEs whose prefix is environment-dependent; derive
+    # them the same way dataframe() does so the test is prefix-agnostic.
+    p1 = acq.client.compact_uri("urn:ex/point_1")   # numeric
+    p9 = acq.client.compact_uri("urn:ex/point_9")   # text
+
+    numeric = df.filter(pl.col("point_id") == p1)
     assert len(numeric) > 0
     # numeric point populated value_numeric (cast succeeded) and not value_text
     assert numeric["value_numeric"].null_count() < len(numeric)
     assert numeric["value_text"].null_count() == len(numeric)
 
-    text = df.filter(pl.col("point_id") == "ex1:point_9")
+    text = df.filter(pl.col("point_id") == p9)
     assert len(text) > 0
     # un-castable text point gracefully stayed in value_text
     assert text["value_numeric"].null_count() == len(text)
@@ -215,8 +226,8 @@ def test_dataframe_cast_int_per_frame_does_not_raise(acquirium_client_csv):
     df = acq.find_all_data().dataframe(shape="narrow", cast_value="int", limit=5)
 
     point_ids = set(df["point_id"].to_list())
-    assert "ex1:point_1" in point_ids   # numeric point present
-    assert "ex1:point_9" in point_ids   # text point still present, not dropped
+    assert acq.client.compact_uri("urn:ex/point_1") in point_ids   # numeric point present
+    assert acq.client.compact_uri("urn:ex/point_9") in point_ids   # text point still present
 
 
 ##### Find data tests #####

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -214,3 +214,36 @@ class TestDataObjectUnits:
         # Original should be unchanged
         assert original_df.equals(after_df)
         assert converted is not data
+
+    def test_convert_to_unresolvable_to_unit_raises(self, acquirium_client):
+        """convert_to() resolves to_unit up front and names it in the error."""
+        acq = acquirium_client
+        data = acq.find_all_data().data()
+
+        with pytest.raises(ValueError, match=r"could not resolve to_unit"):
+            data.convert_to("NoSuchUnit12345")
+
+    def test_convert_to_unresolvable_from_unit_raises(self, acquirium_client):
+        """An unresolvable from_unit is reported before any conversion runs."""
+        acq = acquirium_client
+        data = acq.find_all_data().data()
+
+        with pytest.raises(ValueError, match=r"could not resolve from_unit"):
+            data.convert_to("L-PER-MIN", from_unit="NoSuchUnit12345")
+
+    def test_convert_to_accepts_full_unit_uri(self, acquirium_client):
+        """to_unit may be a full QUDT URI, not only a label/UCUM code."""
+        acq = acquirium_client
+        data = acq.find_all_data().data()
+
+        units = data.units()
+        alias_with_unit = next(
+            (a for a, u in units.items() if u and "MilliL-PER-MIN" in u), None
+        )
+        if alias_with_unit is None:
+            pytest.skip("No alias with MilliL-PER-MIN unit in test model")
+
+        converted = data.convert_to(
+            "http://qudt.org/vocab/unit/L-PER-MIN", alias=alias_with_unit
+        )
+        assert isinstance(converted, type(data))

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "acquirium"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-postgresql" },


### PR DESCRIPTION
This pull request introduces several improvements to how URIs and namespaces are handled throughout the codebase, focusing on better support for CURIEs (compact URIs), more consistent use of namespace bindings, and improved robustness in data type casting. The changes affect both client-side logic for handling URIs and server-side graph storage, aiming for more readable outputs and more reliable unit conversions.

**URI and Namespace Handling Improvements:**

* Added new methods `compact_uri` and `expand_uri` to the `client.py` class, enabling conversion between full URIs and CURIEs using bound namespaces, and updated all relevant code to use `compact_uri` instead of `strip_namespace` for more informative and readable labels and keys. [[1]](diffhunk://#diff-19906b6e3cbd36b6443b58bad60c6b248c7cee42af42621d797734df47932083R251-R288) [[2]](diffhunk://#diff-204a088f6aff11fe331f7584ae6004550f6e3db70b4e4cbb0175b4fcde8bcc7bL659-R657) [[3]](diffhunk://#diff-3aa270464d66cb86e2ae9b1c20ad7defa70acba18d01d881ca372f0feecd44c3L717-R727) [[4]](diffhunk://#diff-3aa270464d66cb86e2ae9b1c20ad7defa70acba18d01d881ca372f0feecd44c3L753-R774) [[5]](diffhunk://#diff-3aa270464d66cb86e2ae9b1c20ad7defa70acba18d01d881ca372f0feecd44c3L790-R796) [[6]](diffhunk://#diff-3aa270464d66cb86e2ae9b1c20ad7defa70acba18d01d881ca372f0feecd44c3L823-R829) [[7]](diffhunk://#diff-3aa270464d66cb86e2ae9b1c20ad7defa70acba18d01d881ca372f0feecd44c3L1463-R1469)
* Enhanced `_normalize_instance_uri` in `query.py` to support CURIE expansion, allowing CURIEs (e.g., `prefix:local`) to be resolved to full URIs if the prefix is bound, improving flexibility in input formats.
* Updated the graph store logic to propagate prefix bindings from incoming RDF graphs, ensuring that namespace prefixes declared in imported data are preserved and available for queries and API endpoints.
* Changed the default `namespace_manager` to use `query_dataset` instead of `source_dataset`, ensuring that namespace bindings are consistent with query operations.

**Data Type Casting Robustness:**

* Improved robustness of value casting in dataframes: moved casting logic to operate on each frame before concatenation, added error handling with warnings for failed casts, and ensured consistent handling in both `data_object.py` and `query.py`. [[1]](diffhunk://#diff-204a088f6aff11fe331f7584ae6004550f6e3db70b4e4cbb0175b4fcde8bcc7bR436-R445) [[2]](diffhunk://#diff-204a088f6aff11fe331f7584ae6004550f6e3db70b4e4cbb0175b4fcde8bcc7bL496-L507) [[3]](diffhunk://#diff-3aa270464d66cb86e2ae9b1c20ad7defa70acba18d01d881ca372f0feecd44c3R752-R761) [[4]](diffhunk://#diff-3aa270464d66cb86e2ae9b1c20ad7defa70acba18d01d881ca372f0feecd44c3L753-R774)

**Unit Conversion Reliability:**

* Refactored unit conversion in `convert_to` to always resolve units to full QUDT URIs before use, raising clear errors if resolution fails, and ensuring conversions are deduplicated and validated per alias. (F5310058L817R815)

These changes collectively improve the clarity, reliability, and flexibility of the codebase when handling URIs, namespaces, and data conversions.